### PR TITLE
Text color

### DIFF
--- a/Instance.js
+++ b/Instance.js
@@ -13,7 +13,7 @@ import {WebGLRenderer} from "./WebGLRenderer.js";
  * 
  * @param {{
  *    shaderPath: String,
- *    texturePath: String
+ *    texturePath: String,
  * }}
  */
 export function Instance({shaderPath, texturePath}) {
@@ -65,7 +65,6 @@ export function Instance({shaderPath, texturePath}) {
 	const outputRenderer = new WebGLRenderer({
 		offscreen: false,
 		generateMipmaps: false,
-		version: 2,
 	});
 
 	/**

--- a/Instance.js
+++ b/Instance.js
@@ -195,10 +195,10 @@ export function Instance({shaderPath, texturePath}) {
 
 		for (let i = 0, rendererManager, renderer; i < rendererLength; i++) {
 			rendererManager = rendererManagers[i];
-			({renderer} = rendererManager);
-
+			renderer = rendererManager.getRenderer();
 			renderer.build();
 			renderer.setViewport(viewport);
+
 			await rendererManager.init();
 
 			this.renderers.push(rendererManager);

--- a/RendererManager.js
+++ b/RendererManager.js
@@ -2,14 +2,15 @@ import {Instance} from "./Instance.js";
 import {WebGLRenderer} from "./WebGLRenderer.js";
 
 /**
- * @todo Add getters
+ * @param {WebGLRenderer} renderer
+ * @param {Instance} instance
  */
-export function RendererManager(instance, renderer) {
-	/** @type {Instance} */
-	this.instance = instance;
+export function RendererManager(renderer, instance) {
+	/** @returns {WebGLRenderer} */
+	this.getRenderer = () => renderer;
 
-	/** @type {WebGLRenderer} */
-	this.renderer = renderer;
+	/** @returns {Instance} */
+	this.getInstance = () => instance;
 }
 
 /** @abstract */

--- a/WebGLRenderer.js
+++ b/WebGLRenderer.js
@@ -6,7 +6,7 @@ import {Program, Texture} from "./wrappers/index.js";
  * General-purpose renderer based on a WebGL context.
  * 
  * @param {{
- *    canvas: HTMLCanvasElement|OffscreenCanvas,
+ *    offscreen: Boolean,
  *    generateMipmaps: Boolean,
  * }}
  * @throws {ReferenceError}

--- a/WebGLRenderer.js
+++ b/WebGLRenderer.js
@@ -2,9 +2,6 @@ import {NoWebGL2Error, ShaderCompilationError} from "./errors/index.js";
 import {Vector2} from "./math/index.js";
 import {Program, Texture} from "./wrappers/index.js";
 
-/** @type {Vector2} */
-const MAX_TEXTURE_SIZE = new Vector2(256, 256);
-
 /**
  * General-purpose renderer based on a WebGL context.
  * 
@@ -136,13 +133,13 @@ export function WebGLRenderer({offscreen, generateMipmaps}) {
 
 	/**
 	 * Binds a new texture array to the context.
-	 * The texture size is capped by `MAX_TEXTURE_SIZE`.
+	 * The texture size is capped by `WebGLRenderer.MAX_TEXTURE_SIZE`.
 	 * 
 	 * @param {Number} length
 	 */
 	this.createTextureArray = function(length) {
 		gl.bindTexture(gl.TEXTURE_2D_ARRAY, gl.createTexture());
-		gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 8, gl.RGBA8, MAX_TEXTURE_SIZE.x, MAX_TEXTURE_SIZE.y, length);
+		gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 8, gl.RGBA8, WebGLRenderer.MAX_TEXTURE_SIZE.x, WebGLRenderer.MAX_TEXTURE_SIZE.y, length);
 		gl.texParameteri(gl.TEXTURE_2D_ARRAY, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
 		generateMipmaps ?
 			gl.generateMipmap(gl.TEXTURE_2D_ARRAY) :
@@ -179,8 +176,8 @@ export function WebGLRenderer({offscreen, generateMipmaps}) {
 			textureSize.x = image.width;
 			textureSize.y = image.height;
 
-			if (textureSize.x > MAX_TEXTURE_SIZE.x || textureSize.y > MAX_TEXTURE_SIZE.y) {
-				throw RangeError("Image size is greater than MAX_TEXTURE_SIZE");
+			if (textureSize.x > WebGLRenderer.MAX_TEXTURE_SIZE.x || textureSize.y > WebGLRenderer.MAX_TEXTURE_SIZE.y) {
+				throw RangeError("Image size is greater than WebGLRenderer.MAX_TEXTURE_SIZE");
 			}
 
 			gl.texSubImage3D(gl.TEXTURE_2D_ARRAY, 0, 0, 0, i, image.width, image.height, 1, gl.RGBA, gl.UNSIGNED_BYTE, image);
@@ -220,3 +217,6 @@ WebGLRenderer.prototype.clear = function() {
 
 	gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 };
+
+/** @type {Vector2} */
+WebGLRenderer.MAX_TEXTURE_SIZE = new Vector2(256, 256);

--- a/WebGLRenderer.js
+++ b/WebGLRenderer.js
@@ -9,16 +9,15 @@ const MAX_TEXTURE_SIZE = new Vector2(256, 256);
  * General-purpose renderer based on a WebGL context.
  * 
  * @param {{
- *    offscreen: Boolean,
+ *    canvas: HTMLCanvasElement|OffscreenCanvas,
  *    generateMipmaps: Boolean,
- *    version: Number,
  * }}
+ * @throws {ReferenceError}
  * @throws {TypeError}
  */
-export function WebGLRenderer({offscreen, generateMipmaps, version}) {
+export function WebGLRenderer({offscreen, generateMipmaps}) {
 	if (typeof offscreen !== "boolean") throw TypeError(`The "offscreen" argument must be of type boolean, received ${typeof offscreen}`);
 	if (typeof generateMipmaps !== "boolean") throw TypeError(`The "generateMipmaps" argument must be of type boolean, received ${typeof generateMipmaps}`);
-	if (version !== 1 && version !== 2) throw TypeError(`Unrecognized WebGL version: ${version}`);
 
 	/** @type {HTMLCanvasElement|OffscreenCanvas} */
 	let canvas;
@@ -56,15 +55,12 @@ export function WebGLRenderer({offscreen, generateMipmaps, version}) {
 	/** @returns {Object<String, Texture>} */
 	this.getTextures = () => textures;
 
-	/**
-	 * @throws {NoWebGL2Error}
-	 */
+	/** @throws {NoWebGL2Error} */
 	this.build = function() {
-		gl = (
-			canvas = offscreen ? new OffscreenCanvas(0, 0) : document.createElement("canvas")
-		).getContext(version === 2 ? "webgl2" : "webgl");
+		canvas = offscreen ? new OffscreenCanvas(0, 0) : document.createElement("canvas");
+		gl = canvas.getContext("webgl2");
 
-		if (gl === null && version === 2) throw new NoWebGL2Error();
+		if (gl === null) throw new NoWebGL2Error();
 	};
 
 	/**

--- a/gui/GUIRenderer.js
+++ b/gui/GUIRenderer.js
@@ -7,7 +7,6 @@ export function GUIRenderer() {
 	WebGLRenderer.call(this, {
 		offscreen: true,
 		generateMipmaps: false,
-		version: 2,
 	});
 
 	/** @type {Object<String, Number>} */

--- a/gui/GUIRenderer.js
+++ b/gui/GUIRenderer.js
@@ -247,7 +247,7 @@ export function GUIRenderer() {
 	 */
 	this.resize = function(viewport, projectionMatrix) {
 		this.setViewport(viewport);
-	 	this.getContext().uniformMatrix3fv(uniforms.projectionMatrix, false, new Float32Array(projectionMatrix));
+	 	this.getContext().uniformMatrix3fv(uniforms.projection, false, new Float32Array(projectionMatrix));
 	};
 }
 

--- a/gui/GUIRenderer.js
+++ b/gui/GUIRenderer.js
@@ -246,20 +246,8 @@ export function GUIRenderer() {
 	 * @param {Matrix3} projectionMatrix
 	 */
 	this.resize = function(viewport, projectionMatrix) {
-		const canvas = this.getCanvas();
-		const gl = this.getContext();
-
-		gl.viewport(
-			0,
-			0,
-			canvas.width = viewport.x,
-			canvas.height = viewport.y,
-		);
-	 	gl.uniformMatrix3fv(
-	 		uniforms.projectionMatrix,
-	 		false,
-	 		new Float32Array(projectionMatrix),
-	 	);
+		this.setViewport(viewport);
+	 	this.getContext().uniformMatrix3fv(uniforms.projectionMatrix, false, new Float32Array(projectionMatrix));
 	};
 }
 

--- a/gui/Subcomponent.js
+++ b/gui/Subcomponent.js
@@ -1,13 +1,16 @@
-import {Vector2} from "../math/index.js";
+import {Vector2, Vector3} from "../math/index.js";
 
 /**
- * @param {{
- *    offset: Vector2,
- *    size: Vector2,
- *    uv: Vector2,
- * }}
+ * @todo Convert `colorMask` to a `Vector4`, with the alpha value being the weight in the mix
+ * 
+ * @param {Object} options
+ * @param {Vector2} options.offset
+ * @param {Vector2} options.size
+ * @param {Vector2} options.uv
+ * @param {Vector3} [options.colorMask=new Vector3(0, 0, 0)]
+ * @param {Number} [options.colorMaskWeight=0]
  */
-export function Subcomponent({offset, size, uv}) {
+export function Subcomponent({offset, size, uv, colorMask = new Vector3(0, 0, 0), colorMaskWeight = 0}) {
 	/** @returns {Vector2} */
 	this.getOffset = () => offset;
 
@@ -22,6 +25,18 @@ export function Subcomponent({offset, size, uv}) {
 
 	/** @param {Vector2} value */
 	this.setUV = value => void (uv = value);
+
+	/** @returns {Vector3} */
+	this.getColorMask = () => colorMask;
+
+	/** @param {Vector3} value */
+	this.setColorMask = value => void (colorMask = value);
+
+	/** @returns {Number} */
+	this.getColorMaskWeight = () => colorMaskWeight;
+
+	/** @param {Number} value */
+	this.setColorMaskWeight = value => void (colorMaskWeight = value);
 }
 
 /** @returns {Subcomponent} */
@@ -30,5 +45,7 @@ Subcomponent.prototype.clone = function() {
 		offset: this.getOffset(),
 		size: this.getSize(),
 		uv: this.getUV(),
+		colorMask: this.getColorMask(),
+		colorMaskWeight: this.getColorMaskWeight(),
 	});
 }

--- a/gui/Subcomponent.js
+++ b/gui/Subcomponent.js
@@ -2,6 +2,7 @@ import {Vector2, Vector3} from "../math/index.js";
 
 /**
  * @todo Convert `colorMask` to a `Vector4`, with the alpha value being the weight in the mix
+ * @todo See `gl.colorMask`
  * 
  * @param {Object} options
  * @param {Vector2} options.offset

--- a/gui/Subcomponent.js
+++ b/gui/Subcomponent.js
@@ -4,7 +4,7 @@ import {Vector2} from "../math/index.js";
  * @param {{
  *    offset: Vector2,
  *    size: Vector2,
- *    uv: Vector2
+ *    uv: Vector2,
  * }}
  */
 export function Subcomponent({offset, size, uv}) {

--- a/gui/components/DynamicComponent.js
+++ b/gui/components/DynamicComponent.js
@@ -8,7 +8,7 @@ import {extend} from "../../utils/index.js";
  * @param {{
  *    onMouseEnter: ?Listener,
  *    onMouseLeave: ?Listener,
- *    onMouseDown: ?Listener
+ *    onMouseDown: ?Listener,
  * }}
  */
 export function DynamicComponent({onMouseEnter, onMouseLeave, onMouseDown}) {

--- a/gui/components/StructuralComponent.js
+++ b/gui/components/StructuralComponent.js
@@ -3,9 +3,7 @@ import {extend} from "../../utils/index.js";
 
 /**
  * @extends Component
- * @param {{
- *    children: Component[]
- * }}
+ * @param {{children: Component[]}}
  */
 export function StructuralComponent({children}) {
 	Component.apply(this, arguments);


### PR DESCRIPTION
## Changes

- Added text color through color masks and color mask weight

### `WebGLRenderer`

- Can only use WebGL2
- `setViewport` no longer returns a value
- `loadTextures` now throws a `ReferenceError` when no texture array is bound
- Added `resize` as an abstract method
- Added `MAX_TEXTURE_SIZE` as a static property

### `RendererManager`

- Swapped parameters (`renderer` is now first)
- Added getters for `renderer` and `instance`

### `GUI`

- All public properties are now private
- Added `subcomponentCount`, which tracks the number of subcomponents in the render queue
- Added a getter for `fontSubcomponents`
- Replaced `renderQueue.push` with the `pushToRenderQueue` method

### `GUIRenderer`

- Moved world and texture matrix attribute/divisor setup in `init`
- Refactored `render` and `resize`

### `Subcomponent`

- Added getters for `colorMask` and `colorMaskWeight`

## Fixes

- Fixed issue #4