### PR TITLE
Add fonts and fix StructuralComponent

### DIFF
--- a/Font.js
+++ b/Font.js
@@ -1,0 +1,49 @@
+import {Subcomponent} from "./gui/index.js";
+
+/**
+ * @param {Object} options
+ * @param {String} options.name
+ * @param {String} options.texturePath
+ * @param {Number} options.letterHeight
+ * @param {Number} options.letterSpacing
+ */
+export function Font({name, texturePath, letterHeight, letterSpacing}) {
+	/** @param {?Object} */
+	let data;
+
+	/** @param {?Object<String, Subcomponent>} */
+	let characters;
+
+	texturePath = `${texturePath}${name}.png`;
+
+	/** @returns {?Object} */
+	this.getData = () => data;
+
+	/** @param {Object} value */
+	this.setData = value => void (data = value);
+
+	/** @returns {?Object<String, Subcomponent>} */
+	this.getCharacters = () => characters;
+
+	/** @param {Object<String, Subcomponent>} value */
+	this.setCharacters = value => void (characters = value);
+
+	/** @returns {String} */
+	this.getName = () => name;
+
+	/** @returns {String} */
+	this.getTexturePath = () => texturePath;
+
+	/** @returns {Number} */
+	this.getLetterHeight = () => letterHeight;
+
+	/** @returns {Number} */
+	this.getLetterSpacing = () => letterSpacing;
+}
+
+/** @param {String} fontPath */
+Font.prototype.load = async function(fontPath) {
+	this.setData(
+		await (await fetch(`${fontPath}${this.getName()}.json`)).json(),
+	);
+};

--- a/Instance.js
+++ b/Instance.js
@@ -350,7 +350,7 @@ export function Instance({fontPath, shaderPath, texturePath}) {
 		/** @type {?WebGL2RenderingContext} */
 		const gl = outputRenderer.getContext();
 
-		if (gl === null) return console.info("This exception occurred before building the instance.");
+		if (gl === null) return console.log("This exception occurred before building the instance.");
 
 		this.stopLoop();
 
@@ -360,7 +360,7 @@ export function Instance({fontPath, shaderPath, texturePath}) {
 
 		outputRenderer.dispose();
 
-		console.info("The instance was properly disposed after catching this exception.");
+		console.log("The instance was properly disposed after catching this exception.");
 	};
 
 	this.addMouseDownListener = function(listener) {
@@ -394,7 +394,9 @@ export function Instance({fontPath, shaderPath, texturePath}) {
 	};
 
 	/**
-	 * Note: only executes one listener at a time.
+	 * Note: Because listeners may push a new layer
+	 * (thus modifying the listener array by discarding the previous ones),
+	 * the loop will break if a listener is called.
 	 */
 	function mouseDownListener() {
 		for (let i = 0, l = mouseDownListenerCount, listener; i < l; i++) {

--- a/Instance.js
+++ b/Instance.js
@@ -1,7 +1,6 @@
 import {Vector2, clampDown, clampUp, intersects} from "./math/index.js";
 import {Program} from "./wrappers/index.js";
-import {RendererManager} from "./RendererManager.js";
-import {WebGLRenderer} from "./WebGLRenderer.js";
+import {RendererManager, WebGLRenderer} from "./index.js";
 
 /**
  * @todo Find a better name
@@ -12,11 +11,12 @@ import {WebGLRenderer} from "./WebGLRenderer.js";
  * This holds information about asset base paths, viewport dimensions and GUI scale.
  * 
  * @param {{
+ *    fontPath: String,
  *    shaderPath: String,
  *    texturePath: String,
  * }}
  */
-export function Instance({shaderPath, texturePath}) {
+export function Instance({fontPath, shaderPath, texturePath}) {
 	const DEFAULT_WIDTH = 320;
 	const DEFAULT_HEIGHT = 240;
 	const RESIZE_DELAY = 50;
@@ -82,6 +82,9 @@ export function Instance({shaderPath, texturePath}) {
 	this.rendererTextures = [];
 
 	/** @returns {String} */
+	this.getFontPath = () => fontPath;
+
+	/** @returns {String} */
 	this.getShaderPath = () => shaderPath;
 
 	/** @returns {String} */
@@ -105,7 +108,7 @@ export function Instance({shaderPath, texturePath}) {
 	 * 
 	 * @type {?Number}
 	 */
-	this.currentScale = 10;
+	this.currentScale = 2;
 
 	/**
 	 * @todo Since this is controlled by the user, move it to a public class?
@@ -114,7 +117,7 @@ export function Instance({shaderPath, texturePath}) {
 	 * 
 	 * @type {?Number}
 	 */
-	this.desiredScale = 10;
+	this.desiredScale = 2;
 
 	/**
 	 * Maximum GUI scale multiplier appliable to the current viewport.
@@ -122,7 +125,7 @@ export function Instance({shaderPath, texturePath}) {
 	 * 
 	 * @type {?Number}
 	 */
-	this.maxScale = 10;
+	this.maxScale = 2;
 
 	/**
 	 * Current position of the pointer, used for GUI event listeners.

--- a/Instance.js
+++ b/Instance.js
@@ -13,6 +13,7 @@ const RESIZE_DELAY = 50;
 
 /**
  * @todo Find a better name
+ * @todo Add getters/setters
  * 
  * This holds information about asset base paths, viewport dimensions and GUI scale.
  * 
@@ -51,7 +52,7 @@ export function Instance({fontPath, shaderPath, texturePath}) {
 	 */
 	let hasBeenBuilt = false;
 
-	/** @todo Replace by `Set`? */
+	/** @todo Replace by Set or Map */
 	let mouseEnterListeners = [],
 		mouseEnterListenerCount = 0,
 		mouseLeaveListeners = [],
@@ -115,8 +116,6 @@ export function Instance({fontPath, shaderPath, texturePath}) {
 	this.currentScale = 2;
 
 	/**
-	 * @todo Since this is controlled by the user, move it to a public class?
-	 * 
 	 * GUI scale multiplier chosen by the user.
 	 * 
 	 * @type {?Number}
@@ -294,7 +293,6 @@ export function Instance({fontPath, shaderPath, texturePath}) {
 		animationRequestId = null;
 	};
 
-	/** @todo Use `Renderer` class to avoid duplicate methods (createProgram/createShader/linkProgram)? */
 	this.initialize = async function() {
 		const gl = outputRenderer.getContext();
 
@@ -311,7 +309,6 @@ export function Instance({fontPath, shaderPath, texturePath}) {
 
 		outputRenderer.linkProgram(program);
 
-		/** @todo Make useProgram helper in `WebGLRenderer`? */
 		gl.useProgram(program.getProgram());
 
 		gl.attribute = {
@@ -335,7 +332,7 @@ export function Instance({fontPath, shaderPath, texturePath}) {
 	};
 
 	/**
-	 * @todo Use instanced drawing
+	 * @todo Use instanced drawing with a texture array
 	 */
 	this.render = function() {
 		const {rendererTextures} = this;
@@ -396,6 +393,9 @@ export function Instance({fontPath, shaderPath, texturePath}) {
 		mouseLeaveListenerCount--;
 	};
 
+	/**
+	 * Note: only executes one listener at a time.
+	 */
 	function mouseDownListener() {
 		for (let i = 0, l = mouseDownListenerCount, listener; i < l; i++) {
 			listener = mouseDownListeners[i];
@@ -403,6 +403,8 @@ export function Instance({fontPath, shaderPath, texturePath}) {
 			if (!intersects(pointerPosition, listener.component.getPosition(), listener.component.getSize())) continue;
 
 			listener(pointerPosition);
+
+			break;
 		}
 	}
 

--- a/Instance.js
+++ b/Instance.js
@@ -105,7 +105,7 @@ export function Instance({shaderPath, texturePath}) {
 	 * 
 	 * @type {?Number}
 	 */
-	this.currentScale = 2;
+	this.currentScale = 10;
 
 	/**
 	 * @todo Since this is controlled by the user, move it to a public class?
@@ -114,7 +114,7 @@ export function Instance({shaderPath, texturePath}) {
 	 * 
 	 * @type {?Number}
 	 */
-	this.desiredScale = 2;
+	this.desiredScale = 10;
 
 	/**
 	 * Maximum GUI scale multiplier appliable to the current viewport.
@@ -122,7 +122,7 @@ export function Instance({shaderPath, texturePath}) {
 	 * 
 	 * @type {?Number}
 	 */
-	this.maxScale = 4;
+	this.maxScale = 10;
 
 	/**
 	 * Current position of the pointer, used for GUI event listeners.

--- a/Instance.js
+++ b/Instance.js
@@ -2,12 +2,18 @@ import {Vector2, clampDown, clampUp, intersects} from "./math/index.js";
 import {Program} from "./wrappers/index.js";
 import {RendererManager, WebGLRenderer} from "./index.js";
 
+/** @type {Number} */
+const DEFAULT_WIDTH = 320;
+
+/** @type {Number} */
+const DEFAULT_HEIGHT = 240;
+
+/** @type {Number} */
+const RESIZE_DELAY = 50;
+
 /**
  * @todo Find a better name
- * @todo Implement render pipeline here
- * @todo Apply settings
  * 
- * Game instance.
  * This holds information about asset base paths, viewport dimensions and GUI scale.
  * 
  * @param {{
@@ -17,10 +23,6 @@ import {RendererManager, WebGLRenderer} from "./index.js";
  * }}
  */
 export function Instance({fontPath, shaderPath, texturePath}) {
-	const DEFAULT_WIDTH = 320;
-	const DEFAULT_HEIGHT = 240;
-	const RESIZE_DELAY = 50;
-
 	/**
 	 * Prevents the first `ResizeObserver` call.
 	 * 
@@ -31,16 +33,16 @@ export function Instance({fontPath, shaderPath, texturePath}) {
 	/**
 	 * Timeout ID of the `ResizeObserver`, used to clear the timeout.
 	 * 
-	 * @type {Number}
+	 * @type {?Number}
 	 */
-	let resizeTimeoutID;
+	let resizeTimeoutId;
 
 	/**
 	 * Animation request ID, used to interrupt the loop.
 	 * 
-	 * @type {Number}
+	 * @type {?Number}
 	 */
-	let animationRequestID;
+	let animationRequestId;
 
 	/**
 	 * Returns `true` if the instance canvas has been added to the DOM, `false` otherwise.
@@ -49,8 +51,7 @@ export function Instance({fontPath, shaderPath, texturePath}) {
 	 */
 	let hasBeenBuilt = false;
 
-	let rendererLength;
-
+	/** @todo Replace by `Set`? */
 	let mouseEnterListeners = [],
 		mouseEnterListenerCount = 0,
 		mouseLeaveListeners = [],
@@ -66,6 +67,9 @@ export function Instance({fontPath, shaderPath, texturePath}) {
 		offscreen: false,
 		generateMipmaps: false,
 	});
+
+	/** @type {?Number} */
+	let rendererLength;
 
 	/**
 	 * Offscreen renderers.
@@ -149,8 +153,8 @@ export function Instance({fontPath, shaderPath, texturePath}) {
 			// Avoid the first resize
 			if (isFirstResize) return isFirstResize = null;
 
-			clearTimeout(resizeTimeoutID);
-			resizeTimeoutID = setTimeout(() => {
+			clearTimeout(resizeTimeoutId);
+			resizeTimeoutId = setTimeout(() => {
 				let width, height, dpr = 1;
 
 				if (entry.devicePixelContentBoxSize) {
@@ -181,8 +185,12 @@ export function Instance({fontPath, shaderPath, texturePath}) {
 			this.resizeObserver.observe(canvas, {box: "content-box"});
 		}
 
-		canvas.onmousemove = mouseMoveListener.bind(this);
-		canvas.onmousedown = mouseDownListener.bind(this);
+		canvas.onmousedown = mouseDownListener;
+		canvas.onmousemove = ({clientX: x, clientY: y}) => {
+			pointerPosition = new Vector2(x, y).multiplyScalar(devicePixelRatio).divideScalar(this.currentScale);
+
+			mouseMoveListener();
+		};
 	};
 
 	this.hasBeenBuilt = () => hasBeenBuilt;
@@ -266,38 +274,27 @@ export function Instance({fontPath, shaderPath, texturePath}) {
 
 		gl.bindTexture(gl.TEXTURE_2D, this.rendererTextures[index]);
 		
-		/** @todo Replace by `texStorage2D` (lower memory costs in some implementations,according to {@link https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.6}) */
+		/** @todo Replace by `texStorage2D` (lower memory costs in some implementations, according to {@link https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.6}) */
 		gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGB, gl.RGB, gl.UNSIGNED_BYTE, canvas);
 	};
 
-	/**
-	 * @todo Better naming
-	 * 
-	 * Starts the game loop.
-	 */
+	/** @todo Find a better name */
 	this.startLoop = () => this.loop();
 
-	/**
-	 * @todo Better naming
-	 * 
-	 * Game loop.
-	 */
 	this.loop = function() {
-		animationRequestID = requestAnimationFrame(this.loop);
+		animationRequestId = requestAnimationFrame(this.loop);
 
 		this.render();
 	}.bind(this);
 
-	/**
-	 * @todo Better naming
-	 * 
-	 * Stops the game loop.
-	 */
-	this.stopLoop = () => cancelAnimationFrame(animationRequestID);
+	/** @todo Find a better name */
+	this.stopLoop = function() {
+		cancelAnimationFrame(animationRequestId);
 
-	/**
-	 * @todo Use `Renderer` class to avoid duplicate methods (createProgram/createShader/linkProgram)?
-	 */
+		animationRequestId = null;
+	};
+
+	/** @todo Use `Renderer` class to avoid duplicate methods (createProgram/createShader/linkProgram)? */
 	this.initialize = async function() {
 		const gl = outputRenderer.getContext();
 
@@ -353,21 +350,20 @@ export function Instance({fontPath, shaderPath, texturePath}) {
 	};
 
 	this.dispose = function() {
+		/** @type {?WebGL2RenderingContext} */
 		const gl = outputRenderer.getContext();
 
 		if (gl === null) return console.info("This exception occurred before building the instance.");
 
-		/** @todo Stop the game loop if it has started */
+		this.stopLoop();
 
-		// Dispose child renderers
 		for (let i = 0; i < rendererLength; i++) this.renderers[i].dispose();
 
-		// Remove the resize observer
-		this.resizeObserver.unobserve(outputRenderer.canvas);
+		this.resizeObserver.unobserve(outputRenderer.getCanvas());
 
 		outputRenderer.dispose();
 
-		return console.info("The instance was properly disposed after catching this exception.");
+		console.info("The instance was properly disposed after catching this exception.");
 	};
 
 	this.addMouseDownListener = function(listener) {
@@ -400,13 +396,17 @@ export function Instance({fontPath, shaderPath, texturePath}) {
 		mouseLeaveListenerCount--;
 	};
 
-	/**
-	 * Manager for the `mouseenter` and `mouseleave` events.
-	 * 
-	 * @param {{x: Number, y: Number}}
-	 */
-	function mouseMoveListener({clientX: x, clientY: y}) {
-		pointerPosition = new Vector2(x, y).multiplyScalar(devicePixelRatio).divideScalar(this.currentScale);
+	function mouseDownListener() {
+		for (let i = 0, l = mouseDownListenerCount, listener; i < l; i++) {
+			listener = mouseDownListeners[i];
+
+			if (!intersects(pointerPosition, listener.component.getPosition(), listener.component.getSize())) continue;
+
+			listener(pointerPosition);
+		}
+	}
+
+	function mouseMoveListener() {
 		let i, l, listener;
 
 		for (i = 0, l = mouseEnterListenerCount; i < l; i++) {
@@ -426,19 +426,6 @@ export function Instance({fontPath, shaderPath, texturePath}) {
 			if (!listener.component.getIsHovered()) continue;
 
 			listener.component.setIsHovered(false);
-			listener(pointerPosition);
-		}
-	}
-
-	/**
-	 * Manager for the `mousedown` event.
-	 */
-	function mouseDownListener() {
-		for (let i = 0, l = mouseDownListenerCount, listener; i < l; i++) {
-			listener = mouseDownListeners[i];
-
-			if (!intersects(pointerPosition, listener.component.getPosition(), listener.component.getSize())) continue;
-
 			listener(pointerPosition);
 		}
 	}

--- a/RendererManager.js
+++ b/RendererManager.js
@@ -1,5 +1,4 @@
-import {Instance} from "./Instance.js";
-import {WebGLRenderer} from "./WebGLRenderer.js";
+import {Instance, WebGLRenderer} from "./index.js";
 
 /**
  * @param {WebGLRenderer} renderer

--- a/WebGLRenderer.js
+++ b/WebGLRenderer.js
@@ -61,8 +61,6 @@ export function WebGLRenderer({offscreen, generateMipmaps}) {
 	};
 
 	/**
-	 * @todo Set viewport size as multiples of 2 to avoid subpixel artifacts? (This only concerns the current use of the lib)
-	 * 
 	 * @param {Vector2} viewport
 	 * @returns {Vector2}
 	 */
@@ -187,8 +185,8 @@ export function WebGLRenderer({offscreen, generateMipmaps}) {
 	};
 
 	/**
-	 * @todo Unbind and delete all linked objects (buffers, textures, etc)
-	 * @todo Return value?
+	 * @todo Unbind and delete all linked objects
+	 * 
 	 * @see {@link https://registry.khronos.org/webgl/extensions/WEBGL_lose_context}
 	 */
 	this.dispose = function() {
@@ -197,6 +195,7 @@ export function WebGLRenderer({offscreen, generateMipmaps}) {
 		// gl.deleteVertexArray(vao);
 		// gl.deleteShader(shader);
 		// gl.deleteProgram(program);
+
 		gl.getExtension("WEBGL_lose_context").loseContext();
 
 		gl = null;

--- a/WebGLRenderer.js
+++ b/WebGLRenderer.js
@@ -200,7 +200,6 @@ export function WebGLRenderer({offscreen, generateMipmaps}) {
 		gl.getExtension("WEBGL_lose_context").loseContext();
 
 		gl = null;
-		canvas.remove();
 		canvas = null;
 	};
 }

--- a/gui/GUI.js
+++ b/gui/GUI.js
@@ -69,7 +69,7 @@ export function GUI(renderer, instance) {
 			[symbol, character] = fontData[i];
 
 			fontSubcomponents[symbol] = new Subcomponent({
-				size: new Vector2(character.width, 8),
+				size: new Vector2(character.width, 18),
 				offset: new Vector2(0, 0),
 				uv: new Vector2(...character.uv),
 			});

--- a/gui/GUIManager.js
+++ b/gui/GUIManager.js
@@ -134,15 +134,13 @@ export function GUIManager(renderer, instance) {
 	};
 
 	/**
-	 * Discards event listeners for the provided component.
+	 * Discards event listeners for the provided components.
 	 * 
 	 * @param {Component[]} components
 	 */
 	this.removeListeners = function(components) {
 		for (let i = 0, l = components.length, component, listener; i < l; i++) {
-			component = components[i];
-
-			if (!(component instanceof DynamicComponent)) continue;
+			if (!((component = components[i]) instanceof DynamicComponent)) continue;
 
 			if (listener = component.getOnMouseDown()) instance.removeMouseDownListener(listener);
 			if (listener = component.getOnMouseEnter()) instance.removeMouseEnterListener(listener);
@@ -163,8 +161,9 @@ export function GUIManager(renderer, instance) {
 		}
 	};
 
+	/** @todo Better way to update the rendered texture */
 	this.render = function() {
-		renderer.render(renderQueue, camera, subcomponentCount);
+		renderer.render(renderQueue, subcomponentCount);
 
 		renderQueue.length = subcomponentCount = 0;
 

--- a/gui/GUIRenderer.js
+++ b/gui/GUIRenderer.js
@@ -1,5 +1,4 @@
 import {WebGLRenderer} from "../index.js";
-import {StructuralComponent} from "./index.js";
 import {Matrix3, Vector2} from "../math/index.js";
 import {extend} from "../utils/index.js";
 import {Texture} from "../wrappers/index.js";
@@ -104,24 +103,22 @@ export function GUIRenderer() {
 		gl.vertexAttribPointer(attributes.colorMaskWeight, 1, gl.FLOAT, false, 0, 0);
 		gl.vertexAttribDivisor(attributes.colorMaskWeight, 1);
 
-		{
-			let i, loc;
+		let i, loc;
 
-			gl.bindBuffer(gl.ARRAY_BUFFER, buffers.world);
+		gl.bindBuffer(gl.ARRAY_BUFFER, buffers.world);
 
-			for (i = 0, loc = attributes.world; i < 3; i++, loc++) {
-				gl.enableVertexAttribArray(loc);
-				gl.vertexAttribPointer(loc, 3, gl.FLOAT, false, 36, i * 12);
-				gl.vertexAttribDivisor(loc, 1);
-			}
+		for (i = 0, loc = attributes.world; i < 3; i++, loc++) {
+			gl.enableVertexAttribArray(loc);
+			gl.vertexAttribPointer(loc, 3, gl.FLOAT, false, 36, i * 12);
+			gl.vertexAttribDivisor(loc, 1);
+		}
 
-			gl.bindBuffer(gl.ARRAY_BUFFER, buffers.texture);
+		gl.bindBuffer(gl.ARRAY_BUFFER, buffers.texture);
 
-			for (i = 0, loc = attributes.texture; i < 3; i++, loc++) {
-				gl.enableVertexAttribArray(loc);
-				gl.vertexAttribPointer(loc, 3, gl.FLOAT, false, 36, i * 12);
-				gl.vertexAttribDivisor(loc, 1);
-			}
+		for (i = 0, loc = attributes.texture; i < 3; i++, loc++) {
+			gl.enableVertexAttribArray(loc);
+			gl.vertexAttribPointer(loc, 3, gl.FLOAT, false, 36, i * 12);
+			gl.vertexAttribDivisor(loc, 1);
 		}
 	};
 
@@ -157,8 +154,6 @@ export function GUIRenderer() {
 	};
 
 	/**
-	 * @todo Optimal render queue: only components with subcomponents
-	 * 
 	 * @override
 	 * @param {Number} subcomponentCount
 	 */
@@ -174,8 +169,6 @@ export function GUIRenderer() {
 		for (let i = 0, j, k = 0, cl = scene.length, component, position, textureIndex = new Uint8Array(1), subcomponents, sl, subcomponent, size, world, texture; i < cl; i++) {
 			component = scene[i];
 			position = component.getPosition();
-
-			if (component instanceof StructuralComponent) continue;
 
 			subcomponents = component.getSubcomponents();
 			textureIndex[0] = component.getTexture().getIndex();

--- a/gui/GUIRenderer.js
+++ b/gui/GUIRenderer.js
@@ -157,6 +157,8 @@ export function GUIRenderer() {
 	};
 
 	/**
+	 * @todo Optimal render queue: only components with subcomponents
+	 * 
 	 * @override
 	 * @param {Number} subcomponentCount
 	 */

--- a/gui/GUIRenderer.js
+++ b/gui/GUIRenderer.js
@@ -1,7 +1,8 @@
+import {WebGLRenderer} from "../index.js";
+import {StructuralComponent} from "./index.js";
 import {Matrix3, Vector2} from "../math/index.js";
 import {extend} from "../utils/index.js";
 import {Texture} from "../wrappers/index.js";
-import {WebGLRenderer} from "../index.js";
 
 export function GUIRenderer() {
 	WebGLRenderer.call(this, {
@@ -173,6 +174,9 @@ export function GUIRenderer() {
 		for (let i = 0, j, k = 0, cl = scene.length, component, position, textureIndex = new Uint8Array(1), subcomponents, sl, subcomponent, size, world, texture; i < cl; i++) {
 			component = scene[i];
 			position = component.getPosition();
+
+			if (component instanceof StructuralComponent) continue;
+
 			subcomponents = component.getSubcomponents();
 			textureIndex[0] = component.getTexture().getIndex();
 			sl = subcomponents.length;

--- a/gui/GUIRenderer.js
+++ b/gui/GUIRenderer.js
@@ -1,7 +1,7 @@
 import {Matrix3, Vector2} from "../math/index.js";
 import {extend} from "../utils/index.js";
 import {Texture} from "../wrappers/index.js";
-import {WebGLRenderer} from "../WebGLRenderer.js";
+import {WebGLRenderer} from "../index.js";
 
 export function GUIRenderer() {
 	WebGLRenderer.call(this, {

--- a/gui/GUIRenderer.js
+++ b/gui/GUIRenderer.js
@@ -157,12 +157,10 @@ export function GUIRenderer() {
 	};
 
 	/**
-	 * @todo Use the `camera` param
-	 * 
 	 * @override
 	 * @param {Number} subcomponentCount
 	 */
-	this.render = function(scene, camera, subcomponentCount) {
+	this.render = function(scene, subcomponentCount) {
 		const
 			gl = this.getContext(),
 			worlds = new Float32Array(subcomponentCount * 9),

--- a/gui/Layer.js
+++ b/gui/Layer.js
@@ -1,7 +1,7 @@
 export function Layer() {}
 
 /**
- * @todo Return an array of components or a single component?
+ * @todo Single or multiple children?
  * 
  * @abstract
  * @returns {Component[]}

--- a/gui/components/Component.js
+++ b/gui/components/Component.js
@@ -1,6 +1,7 @@
 import {Matrix3, Vector2} from "../../math/index.js";
 
 /**
+ * @todo Remove `parent` property
  * @param {{
  *    align: Number,
  *    margin: Vector2,

--- a/gui/components/Component.js
+++ b/gui/components/Component.js
@@ -45,7 +45,7 @@ export function Component({align, margin, size}) {
 			case Component.alignCenterTop:
 			case Component.alignCenter:
 			case Component.alignCenterBottom:
-				initial.x += o.x / 2 + m.x;
+				initial.x += o.x * .5 + m.x;
 
 				break;
 			case Component.alignRightTop:
@@ -66,7 +66,7 @@ export function Component({align, margin, size}) {
 			case Component.alignLeftCenter:
 			case Component.alignCenter:
 			case Component.alignRightCenter:
-				initial.y += o.y / 2 + m.y;
+				initial.y += o.y * .5 + m.y;
 
 				break;
 			case Component.alignLeftBottom:

--- a/gui/components/Component.js
+++ b/gui/components/Component.js
@@ -1,7 +1,6 @@
 import {Matrix3, Vector2} from "../../math/index.js";
 
 /**
- * @todo Remove `parent` property
  * @param {{
  *    align: Number,
  *    margin: Vector2,
@@ -12,9 +11,6 @@ export function Component({align, margin, size}) {
 	/** @type {?Vector2} */
 	let position;
 
-	/** @type {?Component} */
-	let parent;
-
 	/**
 	 * Computes the absolute position of the component
 	 * by using its alignment and margin.
@@ -23,13 +19,6 @@ export function Component({align, margin, size}) {
 	 * @param {Vector2} parentSize
 	 */
 	this.computePosition = function(initial, parentSize) {
-		const parent = this.getParent();
-
-		if (parent) {
-			initial = parent.getPosition().clone();
-			parentSize = parent.getSize().clone();
-		}
-
 		const
 			m = margin,
 			o = parentSize.subtract(size);
@@ -86,12 +75,6 @@ export function Component({align, margin, size}) {
 
 	/** @param {Vector2} value */
 	this.setPosition = value => void (position = value);
-
-	/** @returns {?Component} */
-	this.getParent = () => parent;
-
-	/** @param {Component} value */
-	this.setParent = value => void (parent = value);
 
 	/** @returns {Number} */
 	this.getAlign = function() {

--- a/gui/components/DynamicComponent.js
+++ b/gui/components/DynamicComponent.js
@@ -6,25 +6,25 @@ import {extend} from "../../utils/index.js";
 /**
  * @extends VisualComponent
  * @param {{
+ *    onMouseDown: ?Listener,
  *    onMouseEnter: ?Listener,
  *    onMouseLeave: ?Listener,
- *    onMouseDown: ?Listener,
  * }}
  */
-export function DynamicComponent({onMouseEnter, onMouseLeave, onMouseDown}) {
+export function DynamicComponent({onMouseDown, onMouseEnter, onMouseLeave}) {
 	VisualComponent.apply(this, arguments);
 
 	/** @type {Boolean} */
 	let isHovered = false;
 
 	/** @type {?Listener} */
-	onMouseEnter &&= configureListener(this, onMouseEnter);
+	onMouseDown &&= configureListener.call(this, onMouseDown);
 
 	/** @type {?Listener} */
-	onMouseLeave &&= configureListener(this, onMouseLeave);
+	onMouseEnter &&= configureListener.call(this, onMouseEnter);
 
 	/** @type {?Listener} */
-	onMouseDown &&= configureListener(this, onMouseDown);
+	onMouseLeave &&= configureListener.call(this, onMouseLeave);
 
 	/** @returns {Boolean} */
 	this.getIsHovered = () => isHovered;
@@ -33,29 +33,29 @@ export function DynamicComponent({onMouseEnter, onMouseLeave, onMouseDown}) {
 	this.setIsHovered = value => void (isHovered = value);
 
 	/** @returns {?Listener} */
+	this.getOnMouseDown = () => onMouseDown;
+
+	/** @param {Listener} value */
+	this.setOnMouseDown = value => void (onMouseDown = configureListener.call(this, value));
+
+	/** @returns {?Listener} */
 	this.getOnMouseEnter = () => onMouseEnter;
 
 	/** @param {Listener} value */
-	this.setOnMouseEnter = value => void (onMouseEnter = configureListener(this, value));
+	this.setOnMouseEnter = value => void (onMouseEnter = configureListener.call(this, value));
 
 	/** @returns {?Listener} */
 	this.getOnMouseLeave = () => onMouseLeave;
 
 	/** @param {Listener} value */
-	this.setOnMouseLeave = value => void (onMouseLeave = configureListener(this, value));
-
-	/** @returns {?Listener} */
-	this.getOnMouseDown = () => onMouseDown;
-
-	/** @param {Listener} value */
-	this.setOnMouseDown = value => void (onMouseDown = configureListener(this, value));
+	this.setOnMouseLeave = value => void (onMouseLeave = configureListener.call(this, value));
 }
 
 extend(DynamicComponent, VisualComponent);
 
-function configureListener(component, listener) {
-	listener = listener.bind(component);
-	listener.component = component;
+function configureListener(listener) {
+	listener = listener.bind(this);
+	listener.component = this;
 
 	return listener;
 }

--- a/gui/components/StructuralComponent.js
+++ b/gui/components/StructuralComponent.js
@@ -10,13 +10,6 @@ export function StructuralComponent({children}) {
 
 	/** @override */
 	this.computePosition = function(initial, parentSize) {
-		const parent = this.getParent();
-
-		if (parent) {
-			initial = parent.getPosition().clone();
-			parentSize = parent.getSize().clone();
-		}
-
 		const align = this.getAlign();
 		const size = this.getSize();
 		const m = this.getMargin();
@@ -55,6 +48,13 @@ export function StructuralComponent({children}) {
 		}
 
 		this.setPosition(initial.floor32());
+
+		const position = this.getPosition();
+		const children = this.getChildren();
+
+		for (let i = 0, l = children.length; i < l; i++) {
+			children[i].computePosition(position.clone(), size);
+		}
 	};
 
 	/** @returns {Component[]} */

--- a/gui/components/StructuralComponent.js
+++ b/gui/components/StructuralComponent.js
@@ -8,6 +8,55 @@ import {extend} from "../../utils/index.js";
 export function StructuralComponent({children}) {
 	Component.apply(this, arguments);
 
+	/** @override */
+	this.computePosition = function(initial, parentSize) {
+		const parent = this.getParent();
+
+		if (parent) {
+			initial = parent.getPosition().clone();
+			parentSize = parent.getSize().clone();
+		}
+
+		const align = this.getAlign();
+		const size = this.getSize();
+		const m = this.getMargin();
+		const o = parentSize.subtract(size);
+
+		initial = initial.add(m);
+
+		switch (align) {
+			case Component.alignCenterTop:
+			case Component.alignCenter:
+			case Component.alignCenterBottom:
+				initial.x += o.x * .5;
+
+				break;
+			case Component.alignRightTop:
+			case Component.alignRightCenter:
+			case Component.alignRightBottom:
+				initial.x = o.x - m.x;
+
+				break;
+		}
+
+		switch (align) {
+			case Component.alignLeftCenter:
+			case Component.alignCenter:
+			case Component.alignRightCenter:
+				initial.y += o.y * .5;
+
+				break;
+			case Component.alignLeftBottom:
+			case Component.alignCenterBottom:
+			case Component.alignRightBottom:
+				initial.y = o.y - m.y;
+
+				break;
+		}
+
+		this.setPosition(initial.floor32());
+	};
+
 	/** @returns {Component[]} */
 	this.getChildren = () => children;
 }

--- a/gui/components/VisualComponent.js
+++ b/gui/components/VisualComponent.js
@@ -2,9 +2,7 @@ import {Component} from "../index.js";
 import {extend} from "../../utils/index.js";
 import {Texture} from "../../wrappers/index.js";
 
-/**
- * @extends Component
- */
+/** @extends Component */
 export function VisualComponent() {
 	Component.apply(this, arguments);
 

--- a/gui/index.js
+++ b/gui/index.js
@@ -2,7 +2,7 @@ export {Component} from "./components/Component.js";
 export {DynamicComponent} from "./components/DynamicComponent.js";
 export {StructuralComponent} from "./components/StructuralComponent.js";
 export {VisualComponent} from "./components/VisualComponent.js";
-export {GUI} from "./GUI.js";
+export {GUIManager} from "./GUIManager.js";
 export {GUIRenderer} from "./GUIRenderer.js";
 export {Layer} from "./Layer.js";
 export {Subcomponent} from "./Subcomponent.js";

--- a/index.js
+++ b/index.js
@@ -1,0 +1,4 @@
+export {Font} from "./Font.js";
+export {Instance} from "./Instance.js";
+export {RendererManager} from "./RendererManager.js";
+export {WebGLRenderer} from "./WebGLRenderer.js";

--- a/math/Matrix3.js
+++ b/math/Matrix3.js
@@ -1,8 +1,6 @@
 import {Vector2} from "./index.js";
 
 /**
- * @todo Matrix inheritance
- * 
  * 3x3 matrix class.
  * 
  * @extends Array

--- a/math/Matrix4.js
+++ b/math/Matrix4.js
@@ -1,8 +1,6 @@
 import {Vector3} from "./index.js";
 
 /**
- * @todo Matrix inheritance
- * 
  * 4x4 matrix class.
  * 
  * @extends Array


### PR DESCRIPTION
### Additions

- Add `src/index.js` for exporting `Font`, `Instance`, `RendererManager` and `WebGLRenderer`
- Rename `GUI` to `GUIManager`
- Font customization with the `Font` class: letter height & letter spacing for the moment
- Support for multiple fonts
- Add the `font` property to `Text` to select the font for this component. Defaults to the font first added to the `GUIManager`.
- Remove `parent` property on `Component`
- Move `Group.computePosition` to `StructuralComponent.computePosition`
- Subtle math optimizations in `Component.computePosition` and `StructuralComponent.computePosition`
- Updated todos

### Fixes

- Fix #2
- Fix #7
- Fix a bug where a `mousedown` listener calling `GUIManager.push` would modify the listener array used by the `mouseDownListener` loop, and cause the index to go out of bounds. **If a `mousedown` listener is fired, the loop will stop there and won't hit-test the next ones.**