### PR TITLE
New features needed by test environment

### DIFF
--- a/Queue/index.js
+++ b/Queue/index.js
@@ -1,1 +1,0 @@
-export {BucketQueue} from "./BucketQueue.js";

--- a/Stack/BucketStack.js
+++ b/Stack/BucketStack.js
@@ -2,7 +2,7 @@
  * @template T
  * @extends {Array<T>}
  */
-export class BucketQueue extends Array {
+export class BucketStack extends Array {
 	/**
 	 * @type {Number[]}
 	 */

--- a/Stack/index.js
+++ b/Stack/index.js
@@ -1,0 +1,1 @@
+export {BucketStack} from "./BucketStack.js";

--- a/errors/NoWebGL2Error.js
+++ b/errors/NoWebGL2Error.js
@@ -1,4 +1,6 @@
 /**
+ * @deprecated
+ * 
  * Represents an error where a `WebGL2RenderingContext` could not be obtained
  * via an `HTMLCanvasElement` or `OffscreenCanvas`.
  */

--- a/errors/NotImplementedError.js
+++ b/errors/NotImplementedError.js
@@ -1,4 +1,6 @@
 /**
+ * @deprecated
+ * 
  * Represents an error where a class method is yet to be implemented.
  * This can act as an exception based TODO tag.
  */

--- a/errors/ShaderCompilationError.js
+++ b/errors/ShaderCompilationError.js
@@ -1,4 +1,6 @@
 /**
+ * @deprecated
+ * 
  * References an error when the binding of a `WebGLProgram` on a
  * `WebGLRenderingContext` fails due to a `WebGLShader` compilation error.
  * 

--- a/gui/Event/KeyPressEvent.js
+++ b/gui/Event/KeyPressEvent.js
@@ -1,10 +1,16 @@
 import {Event} from "./index.js";
 
 /**
+ * @typedef {Object} KeyEventCarry
+ * @property {String} key
+ * @property {String} code
+ */
+
+/**
  * Wrapper for the DOM event "keydown".
  * Note: Fired only once per key press.
  * 
- * @extends {Event<String>}
+ * @extends {Event<KeyEventCarry>}
  */
 export class KeyPressEvent extends Event {
 	static NAME = "key_press";

--- a/gui/Event/KeyReleaseEvent.js
+++ b/gui/Event/KeyReleaseEvent.js
@@ -3,7 +3,7 @@ import {Event} from "./index.js";
 /**
  * Wrapper for the DOM event "keyup".
  * 
- * @extends {Event<String>}
+ * @extends {Event<import("./KeyPressEvent.js").KeyEventCarry>}
  */
 export class KeyReleaseEvent extends Event {
 	static NAME = "key_release";

--- a/gui/Event/KeyRepeatEvent.js
+++ b/gui/Event/KeyRepeatEvent.js
@@ -4,7 +4,7 @@ import {Event} from "./index.js";
  * Wrapper for the DOM event "keydown".
  * Note: Fired repeatedly after a `KeyPressEvent` was fired.
  * 
- * @extends {Event<String>}
+ * @extends {Event<import("./KeyPressEvent.js").KeyEventCarry>}
  */
 export class KeyRepeatEvent extends Event {
 	static NAME = "key_repeat";

--- a/gui/GUIComposite.js
+++ b/gui/GUIComposite.js
@@ -346,21 +346,36 @@ export class GUIComposite extends Composite {
 	 * @param {KeyboardEvent} event
 	 */
 	onKeyPress(event) {
-		this.dispatchEvent(new KeyPressEvent(event.code));
+		const carry = {
+			key: event.key,
+			code: event.code,
+		};
+
+		this.dispatchEvent(new KeyPressEvent(carry));
 	}
 
 	/**
 	 * @param {KeyboardEvent} event
 	 */
 	onKeyRepeat(event) {
-		this.dispatchEvent(new KeyRepeatEvent(event.code));
+		const carry = {
+			key: event.key,
+			code: event.code,
+		};
+
+		this.dispatchEvent(new KeyRepeatEvent(carry));
 	}
 
 	/**
 	 * @param {KeyboardEvent} event
 	 */
 	onKeyRelease(event) {
-		this.dispatchEvent(new KeyReleaseEvent(event.code));
+		const carry = {
+			key: event.key,
+			code: event.code,
+		};
+
+		this.dispatchEvent(new KeyReleaseEvent(carry));
 	}
 
 	/**

--- a/gui/GUIComposite.js
+++ b/gui/GUIComposite.js
@@ -4,8 +4,8 @@ import {Event, KeyPressEvent, KeyReleaseEvent, KeyRepeatEvent, MouseDownEvent, M
 import {Composite, Instance} from "../index.js";
 import {Camera, OrthographicCamera} from "../cameras/index.js";
 import {Font} from "../fonts/index.js";
-import {Matrix3, Vector2, intersects} from "../math/index.js";
-import {BucketQueue} from "../Queue/index.js";
+import {Matrix3, Vector2} from "../math/index.js";
+import {BucketStack} from "../Stack/index.js";
 import {GUIScene} from "../Scene/index.js";
 import {TextureWrapper} from "../wrappers/index.js";
 
@@ -43,7 +43,7 @@ export class GUIComposite extends Composite {
 	#lastInsertionIndices;
 
 	/**
-	 * @type {Record.<String, BucketQueue.<Function>>}
+	 * @type {Record.<String, BucketStack.<Function>>}
 	 */
 	#eventListeners;
 
@@ -420,7 +420,7 @@ export class GUIComposite extends Composite {
 			}
 
 			if (!(eventName in this.#eventListeners)) {
-				this.#eventListeners[eventName] = new BucketQueue();
+				this.#eventListeners[eventName] = new BucketStack();
 			}
 
 			eventListener = component[eventName].bind(component);
@@ -434,12 +434,12 @@ export class GUIComposite extends Composite {
 	 */
 	#sealEventListenerBuckets() {
 		/**
-		 * @type {BucketQueue[]}
+		 * @type {BucketStack[]}
 		 */
-		const eventListenerQueues = Object.values(this.#eventListeners);
+		const eventListenerStacks = Object.values(this.#eventListeners);
 
-		for (let i = 0, length = eventListenerQueues.length; i < length; i++) {
-			eventListenerQueues[i].sealBucket();
+		for (let i = 0, length = eventListenerStacks.length; i < length; i++) {
+			eventListenerStacks[i].sealBucket();
 		}
 	}
 
@@ -448,12 +448,12 @@ export class GUIComposite extends Composite {
 	 */
 	#popEventListenerBuckets() {
 		/**
-		 * @type {BucketQueue[]}
+		 * @type {BucketStack[]}
 		 */
-		const eventListenerQueues = Object.values(this.#eventListeners);
+		const eventListenerStacks = Object.values(this.#eventListeners);
 
-		for (let i = 0, length = eventListenerQueues.length; i < length; i++) {
-			eventListenerQueues[i].popBucket();
+		for (let i = 0, length = eventListenerStacks.length; i < length; i++) {
+			eventListenerStacks[i].popBucket();
 		}
 	}
 

--- a/gui/GUIComposite.js
+++ b/gui/GUIComposite.js
@@ -215,7 +215,7 @@ export class GUIComposite extends Composite {
 			component = this.#tree[i];
 
 			if (component instanceof StructuralComponent) {
-				this.#addChildrenToRenderQueue(component.getChildren(), false);
+				this.#addChildrenToRenderQueue(component.getChildren(), false, true);
 
 				continue;
 			}
@@ -248,7 +248,7 @@ export class GUIComposite extends Composite {
 		const rootComponent = this.#buildLayer(layer);
 
 		this.#rootComponents.push(rootComponent);
-		this.#addChildrenToRenderQueue([rootComponent], true);
+		this.#addChildrenToRenderQueue([rootComponent], true, true);
 		this.#sealEventListenerBuckets();
 
 		this.compute();
@@ -334,7 +334,7 @@ export class GUIComposite extends Composite {
 			return;
 		}
 
-		this.#addChildrenToRenderQueue(this.#tree, false);
+		this.#addChildrenToRenderQueue(this.#tree, false, false);
 
 		this._renderer.clear();
 
@@ -381,15 +381,17 @@ export class GUIComposite extends Composite {
 	 * Populates recursively the component tree.
 	 * 
 	 * @param {Component[]} children
-	 * @param {Object} options
-	 * @param {Boolean} [options.addToTree]
+	 * @param {Boolean} addToTree
+	 * @param {Boolean} registerEvents
 	 */
-	#addChildrenToRenderQueue(children, addToTree = false) {
+	#addChildrenToRenderQueue(children, addToTree, registerEvents) {
 		for (let i = 0, l = children.length, component; i < l; i++) {
 			component = children[i];
 			component.setEventDispatcher(this);
 
-			this.#pushEventListeners(component);
+			if (registerEvents) {
+				this.#pushEventListeners(component);
+			}
 
 			if (!(component instanceof StructuralComponent)) {
 				this._scene.add(component);
@@ -402,7 +404,7 @@ export class GUIComposite extends Composite {
 				continue;
 			}
 
-			this.#addChildrenToRenderQueue(component.getChildren(), addToTree);
+			this.#addChildrenToRenderQueue(component.getChildren(), addToTree, registerEvents);
 		}
 	}
 


### PR DESCRIPTION
- Keyboard events (`KeyPressEvent`, `KeyReleaseEvent` and `KeyRepeatEvent`) now carry an object with the native event's `key` and `code`.
- Custom errors are **deprecated**.
- `BucketQueue` has been renamed to `BucketStack`.
- Fixed GUI composite events being registered again on each layer pop.