### PR TITLE
Subcomponent scale

### DIFF
--- a/fonts/BitmapFont.js
+++ b/fonts/BitmapFont.js
@@ -164,10 +164,11 @@ export class BitmapFont extends Font {
 	 * Generates an array of glyph subcomponents from a single-line string.
 	 * 
 	 * @param {String} string
+	 * @param {Number} fontSize
 	 * @param {Vector4} colorMask
 	 * @throws {Error} if the string contains newlines
 	 */
-	generateGlyphsFromString(string, colorMask) {
+	generateGlyphsFromString(string, fontSize, colorMask) {
 		if (string.includes("\n")) {
 			throw new Error("Please use generateGlyphsFromMultilineString to include newlines in your string.");
 		}
@@ -182,11 +183,12 @@ export class BitmapFont extends Font {
 
 			glyph = this.#glyphs[string[i]].clone();
 			glyph.setOffset(new Vector2(size[0] + this.getTileOffset(string[i]), 0));
+			glyph.setScale(new Vector2(fontSize, fontSize));
 			glyph.setColorMask(colorMask.clone());
 
 			glyphs.push(glyph);
 
-			size[0] += this.getTileWidth(string[i]) + this.#tileSpacing;
+			size[0] += (this.getTileWidth(string[i]) + this.#tileSpacing) * fontSize;
 		}
 
 		return {glyphs, size};
@@ -198,9 +200,10 @@ export class BitmapFont extends Font {
 	 * Generates an array of glyph subcomponents from a multi-line string.
 	 * 
 	 * @param {String} string Can be multiline
+	 * @param {Number} fontSize
 	 * @param {Vector4} colorMask
 	 */
-	generateGlyphsFromMultilineString(string, colorMask) {
+	generateGlyphsFromMultilineString(string, fontSize, colorMask) {
 		const lines = string.split("\n");
 
 		const glyphs = [];
@@ -218,15 +221,16 @@ export class BitmapFont extends Font {
 
 				glyph = this.#glyphs[line[j]].clone();
 				glyph.setOffset(new Vector2(lineWidth + this.getTileOffset(line[j]), size[1]));
+				glyph.setScale(new Vector2(fontSize, fontSize));
 				glyph.setColorMask(colorMask.clone());
 
 				glyphs.push(glyph);
 
-				lineWidth += this.getTileWidth(line[j]) + this.#tileSpacing;
+				lineWidth += (this.getTileWidth(line[j]) + this.#tileSpacing) * fontSize;
 			}
 
 			size[0] = max(size[0], lineWidth);
-			size[1] += this.#tileHeight + this.getLineSpacing();
+			size[1] += (this.#tileHeight + this.getLineSpacing()) * fontSize;
 		}
 
 		return {glyphs, size};

--- a/gui/Component/Component.js
+++ b/gui/Component/Component.js
@@ -130,6 +130,9 @@ export class Component {
 			.floor();
 	}
 
+	/**
+	 * @todo Use within the GUI renderer to create the subcomponent world matrix
+	 */
 	getWorld() {
 		return Matrix3
 			.translation(this.#position)

--- a/gui/GUIRenderer.js
+++ b/gui/GUIRenderer.js
@@ -146,7 +146,7 @@ export class GUIRenderer extends WebGLRenderer {
 				size = subcomponent.getSize();
 				world = Matrix3
 					.translation(position.clone().add(subcomponent.getOffset()))
-					.multiply(Matrix3.scale(size));
+					.multiply(Matrix3.scale(size.clone().multiply(subcomponent.getScale())));
 				texture = Matrix3
 					.translation(subcomponent.getUV().clone().divide(WebGLRenderer.MAX_TEXTURE_SIZE))
 					.multiply(Matrix3.scale(size.clone().divide(WebGLRenderer.MAX_TEXTURE_SIZE)));

--- a/gui/Subcomponent.js
+++ b/gui/Subcomponent.js
@@ -2,8 +2,9 @@ import {Vector2, Vector4} from "../math/index.js";
 
 /**
  * @typedef {Object} SubcomponentDescriptor
- * @property {Vector2} size
  * @property {Vector2} [offset]
+ * @property {Vector2} size
+ * @property {Vector2} [scale]
  * @property {Vector2} [uv]
  * @property {Vector4} [colorMask]
  */
@@ -15,12 +16,17 @@ export class Subcomponent {
 	/**
 	 * @type {Vector2}
 	 */
+	#offset;
+
+	/**
+	 * @type {Vector2}
+	 */
 	#size;
 
 	/**
 	 * @type {Vector2}
 	 */
-	#offset;
+	#scale;
 
 	/**
 	 * @type {Vector2}
@@ -36,10 +42,22 @@ export class Subcomponent {
 	 * @param {SubcomponentDescriptor} descriptor
 	 */
 	constructor(descriptor) {
-		this.#size = descriptor.size;
 		this.#offset = descriptor.offset ?? new Vector2();
+		this.#size = descriptor.size;
+		this.#scale = descriptor.scale ?? new Vector2(1, 1);
 		this.#uv = descriptor.uv ?? new Vector2();
 		this.#colorMask = descriptor.colorMask ?? new Vector4(255, 255, 255, 255);
+	}
+
+	getOffset() {
+		return this.#offset;
+	}
+
+	/**
+	 * @param {Vector2} offset
+	 */
+	setOffset(offset) {
+		this.#offset = offset;
 	}
 
 	getSize() {
@@ -53,15 +71,15 @@ export class Subcomponent {
 		this.#size = size;
 	}
 
-	getOffset() {
-		return this.#offset;
+	getScale() {
+		return this.#scale;
 	}
 
 	/**
-	 * @param {Vector2} offset
+	 * @param {Vector2} scale
 	 */
-	setOffset(offset) {
-		this.#offset = offset;
+	setScale(scale) {
+		this.#scale = scale;
 	}
 
 	getUV() {
@@ -88,8 +106,9 @@ export class Subcomponent {
 
 	clone() {
 		return new Subcomponent({
-			size: this.#size,
 			offset: this.#offset,
+			size: this.#size,
+			scale: this.#scale,
 			uv: this.#uv,
 			colorMask: this.#colorMask,
 		});


### PR DESCRIPTION
- Update the `Subcomponent` descriptor property order
- Add a new `fontSize` parameter to `BitmapFont`'s glyph string generators
- Add `Subcomponent` scale property, which is a `Vector2` controlling the X/Y scale of the subcomponent
- Add a new todo for using the `Component.getWorld` method