### PR TITLE
Remove @abstract annotations

### DIFF
--- a/Instance.js
+++ b/Instance.js
@@ -1,9 +1,6 @@
 import {Composite, InstanceRenderer} from "./index.js";
 import {Vector2, Vector4} from "./math/index.js";
 
-/**
- * @abstract
- */
 export class Instance {
 	/**
 	 * @type {InstanceRenderer}

--- a/InstanceRenderer.js
+++ b/InstanceRenderer.js
@@ -4,9 +4,16 @@ import {ShaderLoader} from "./Loader/index.js";
 
 export class InstanceRenderer extends WebGLRenderer {
 	/**
+	 * @override
 	 * @type {?HTMLCanvasElement}
 	 */
 	_canvas;
+
+	/**
+	 * @override
+	 * @type {WebGLTexture[]}
+	 */
+	_textures;
 
 	/**
 	 * @type {Number}
@@ -22,6 +29,7 @@ export class InstanceRenderer extends WebGLRenderer {
 		super();
 
 		this._canvas = null;
+		this._textures = [];
 		this.#compositeCount = 0;
 		this.#shaderPath = "";
 	}

--- a/InstanceRenderer.js
+++ b/InstanceRenderer.js
@@ -2,9 +2,6 @@ import {WebGLRenderer} from "./WebGLRenderer.js";
 import {NoWebGL2Error} from "./Error/index.js";
 import {ShaderLoader} from "./Loader/index.js";
 
-/**
- * @abstract
- */
 export class InstanceRenderer extends WebGLRenderer {
 	/**
 	 * @type {?HTMLCanvasElement}

--- a/gui/GUIRenderer.js
+++ b/gui/GUIRenderer.js
@@ -5,6 +5,7 @@ import {GUIScene} from "../Scene/index.js";
 
 export class GUIRenderer extends WebGLRenderer {
 	/**
+	 * @override
 	 * @type {?OffscreenCanvas}
 	 */
 	_canvas;


### PR DESCRIPTION
Allow [Instance](https://github.com/matteokeole/raven/blob/main/Instance.js) and [InstanceRenderer](https://github.com/matteokeole/raven/blob/main/InstanceRenderer.js) to be instantiable, conforming to their JSDoc.

Also fixed the [InstanceRenderer._textures](https://github.com/matteokeole/raven/blob/main/InstanceRenderer.js) type overriding.