### PR TITLE
Instance and GUI shaders

### DIFF
--- a/Instance.js
+++ b/Instance.js
@@ -87,7 +87,6 @@ export class Instance {
 		this._parameters = {
 			current_scale: 1,
 			font_path: "/",
-			shader_path: "/",
 			texture_path: "/",
 			resize_delay: 0,
 		};
@@ -172,7 +171,6 @@ export class Instance {
 
 	async build() {
 		this.#renderer.setCompositeCount(this.#compositeCount);
-		this.#renderer.setShaderPath(this._parameters["shader_path"]);
 		this.#renderer.build();
 
 		const viewport = new Vector4(0, 0, innerWidth, innerHeight)

--- a/Instance.js
+++ b/Instance.js
@@ -86,6 +86,7 @@ export class Instance {
 		this.#pointer = new Vector2();
 		this._parameters = {
 			current_scale: 1,
+			root_path: "/",
 			font_path: "/",
 			texture_path: "/",
 			resize_delay: 0,
@@ -169,7 +170,7 @@ export class Instance {
 
 	async build() {
 		this.#renderer.setCompositeCount(this.#compositeCount);
-		this.#renderer.build();
+		this.#renderer.build(`${this._parameters["root_path"]}shaders/`);
 
 		const viewport = new Vector4(0, 0, innerWidth, innerHeight)
 			.multiplyScalar(devicePixelRatio)

--- a/Instance.js
+++ b/Instance.js
@@ -135,11 +135,10 @@ export class Instance {
 
 	/**
 	 * @param {String} key
-	 * @throws {ReferenceError}
 	 */
 	getParameter(key) {
 		if (!(key in this._parameters)) {
-			throw new ReferenceError(`Undefined parameter key "${key}".`);
+			return undefined;
 		}
 
 		return this._parameters[key];
@@ -148,11 +147,10 @@ export class Instance {
 	/**
 	 * @param {String} key
 	 * @param {*} value
-	 * @throws {ReferenceError}
 	 */
 	setParameter(key, value) {
 		if (!(key in this._parameters)) {
-			throw new ReferenceError(`Undefined parameter key "${key}".`);
+			return;
 		}
 
 		this._parameters[key] = value;

--- a/InstanceRenderer.js
+++ b/InstanceRenderer.js
@@ -16,17 +16,11 @@ export class InstanceRenderer extends WebGLRenderer {
 	 */
 	#compositeCount;
 
-	/**
-	 * @type {String}
-	 */
-	#shaderPath;
-
 	constructor() {
 		super();
 
 		this._canvas = null;
 		this.#compositeCount = 0;
-		this.#shaderPath = "";
 	}
 
 	getCanvas() {
@@ -38,13 +32,6 @@ export class InstanceRenderer extends WebGLRenderer {
 	 */
 	setCompositeCount(compositeCount) {
 		this.#compositeCount = compositeCount;
-	}
-
-	/**
-	 * @param {String} shaderPath
-	 */
-	setShaderPath(shaderPath) {
-		this.#shaderPath = shaderPath;
 	}
 
 	async build() {
@@ -59,9 +46,9 @@ export class InstanceRenderer extends WebGLRenderer {
 		this._context.enable(this._context.BLEND);
 		this._context.blendFunc(this._context.SRC_ALPHA, this._context.ONE_MINUS_SRC_ALPHA);
 
-		const loader = new ShaderLoader(this.#shaderPath);
-		const vertexShaderSource = await loader.load("composite.vert");
-		const fragmentShaderSource = await loader.load("composite.frag");
+		const loader = new ShaderLoader("./shaders/");
+		const vertexShaderSource = await loader.load("instance.vert");
+		const fragmentShaderSource = await loader.load("instance.frag");
 
 		const program = this._createProgram(vertexShaderSource, fragmentShaderSource);
 

--- a/InstanceRenderer.js
+++ b/InstanceRenderer.js
@@ -34,7 +34,10 @@ export class InstanceRenderer extends WebGLRenderer {
 		this.#compositeCount = compositeCount;
 	}
 
-	async build() {
+	/**
+	 * @param {String} shaderPath
+	 */
+	async build(shaderPath) {
 		this._canvas = document.createElement("canvas");
 		this._context = this._canvas.getContext("webgl2");
 
@@ -46,7 +49,7 @@ export class InstanceRenderer extends WebGLRenderer {
 		this._context.enable(this._context.BLEND);
 		this._context.blendFunc(this._context.SRC_ALPHA, this._context.ONE_MINUS_SRC_ALPHA);
 
-		const loader = new ShaderLoader("./shaders/");
+		const loader = new ShaderLoader(shaderPath);
 		const vertexShaderSource = await loader.load("instance.vert");
 		const fragmentShaderSource = await loader.load("instance.frag");
 

--- a/WebGLRenderer.js
+++ b/WebGLRenderer.js
@@ -110,8 +110,9 @@ export class WebGLRenderer {
 
 	/**
 	 * @abstract
+	 * @param {String} shaderPath
 	 */
-	build() {}
+	build(shaderPath) {}
 
 	/**
 	 * @param {String} vertexShaderSource

--- a/gui/GUIComposite.js
+++ b/gui/GUIComposite.js
@@ -124,7 +124,6 @@ export class GUIComposite extends Composite {
 			.orthographic(viewport)
 			.multiply(Matrix3.scale(new Vector2(scale, scale)));
 
-		this._renderer.setShaderPath(this.getInstance().getParameter("shader_path"));
 		this._renderer.setProjection(projection);
 		this.#camera.setProjection(projection);
 

--- a/gui/GUIComposite.js
+++ b/gui/GUIComposite.js
@@ -127,7 +127,7 @@ export class GUIComposite extends Composite {
 		this._renderer.setProjection(projection);
 		this.#camera.setProjection(projection);
 
-		await this._renderer.build();
+		await this._renderer.build(`${this.getInstance().getParameter("root_path")}shaders/`);
 	}
 
 	/**

--- a/gui/GUIRenderer.js
+++ b/gui/GUIRenderer.js
@@ -10,11 +10,6 @@ export class GUIRenderer extends WebGLRenderer {
 	_canvas;
 
 	/**
-	 * @type {String}
-	 */
-	#shaderPath;
-
-	/**
 	 * @type {Matrix3}
 	 */
 	#projection;
@@ -23,19 +18,11 @@ export class GUIRenderer extends WebGLRenderer {
 		super();
 
 		this._canvas = null;
-		this.#shaderPath = "";
 		this.#projection = Matrix3.identity();
 	}
 
 	getCanvas() {
 		return this._canvas;
-	}
-
-	/**
-	 * @param {String} shaderPath
-	 */
-	setShaderPath(shaderPath) {
-		this.#shaderPath = shaderPath;
 	}
 
 	/**
@@ -54,9 +41,9 @@ export class GUIRenderer extends WebGLRenderer {
 		this._context.enable(this._context.BLEND);
 		this._context.blendFunc(this._context.SRC_ALPHA, this._context.ONE_MINUS_SRC_ALPHA);
 
-		const loader = new ShaderLoader(this.#shaderPath);
-		const vertexShaderSource = await loader.load("subcomponent.vert");
-		const fragmentShaderSource = await loader.load("subcomponent.frag");
+		const loader = new ShaderLoader("../shaders/");
+		const vertexShaderSource = await loader.load("gui.vert");
+		const fragmentShaderSource = await loader.load("gui.frag");
 
 		const program = this._createProgram(vertexShaderSource, fragmentShaderSource);
 

--- a/gui/GUIRenderer.js
+++ b/gui/GUIRenderer.js
@@ -32,8 +32,11 @@ export class GUIRenderer extends WebGLRenderer {
 		this.#projection = projection;
 	}
 
-	async build() {
-		super.build();
+	/**
+	 * @param {String} shaderPath
+	 */
+	async build(shaderPath) {
+		super.build(shaderPath);
 
 		this._canvas = new OffscreenCanvas(0, 0);
 		this._context = this._canvas.getContext("webgl2");
@@ -41,7 +44,7 @@ export class GUIRenderer extends WebGLRenderer {
 		this._context.enable(this._context.BLEND);
 		this._context.blendFunc(this._context.SRC_ALPHA, this._context.ONE_MINUS_SRC_ALPHA);
 
-		const loader = new ShaderLoader("../shaders/");
+		const loader = new ShaderLoader(shaderPath);
 		const vertexShaderSource = await loader.load("gui.vert");
 		const fragmentShaderSource = await loader.load("gui.frag");
 

--- a/shaders/gui.frag
+++ b/shaders/gui.frag
@@ -1,0 +1,18 @@
+#version 300 es
+
+precision mediump float;
+precision mediump sampler2DArray;
+
+flat in uint v_texture_index;
+in vec2 v_uv;
+in vec4 v_color_mask;
+
+uniform sampler2DArray u_sampler;
+
+out vec4 FragColor;
+
+void main() {
+	vec4 texture = texture(u_sampler, vec3(v_uv, v_texture_index));
+
+	FragColor = texture * v_color_mask;
+}

--- a/shaders/gui.vert
+++ b/shaders/gui.vert
@@ -1,0 +1,23 @@
+#version 300 es
+
+layout(location = 0) in vec2 a_vertex;
+layout(location = 1) in mat3 a_world;
+layout(location = 4) in uint a_texture_index;
+layout(location = 5) in mat3 a_texture;
+layout(location = 8) in vec4 a_color_mask;
+
+uniform mat3 u_projection;
+
+flat out uint v_texture_index;
+out vec2 v_uv;
+out vec4 v_color_mask;
+
+void main() {
+	vec3 position = vec3(a_vertex, 1);
+
+	gl_Position = vec4(u_projection * a_world * position, 1);
+
+	v_texture_index = a_texture_index;
+	v_uv = (a_texture * position).xy;
+	v_color_mask = a_color_mask;
+}

--- a/shaders/instance.frag
+++ b/shaders/instance.frag
@@ -1,0 +1,13 @@
+#version 300 es
+
+precision mediump float;
+
+in vec2 v_uv;
+
+uniform sampler2D u_sampler;
+
+out vec4 FragColor;
+
+void main() {
+	FragColor = texture(u_sampler, v_uv);
+}

--- a/shaders/instance.vert
+++ b/shaders/instance.vert
@@ -1,0 +1,11 @@
+#version 300 es
+
+layout(location = 0) in vec2 a_vertex;
+
+out vec2 v_uv;
+
+void main() {
+	gl_Position = vec4(a_vertex, 0, 1);
+
+	v_uv = a_vertex * .5 + .5;
+}


### PR DESCRIPTION
Add instance and GUI vertex/fragment shaders (which should be in the library and not the client).

[Instance.getParameter](https://github.com/matteokeole/raven/blob/e5cb3da0b5357edcdedffaa651662a81714b7bb3/Instance.js#L141) and [Instance.setParameter](https://github.com/matteokeole/raven/blob/e5cb3da0b5357edcdedffaa651662a81714b7bb3/Instance.js#L154) do not throw anymore when the key does not exist in the parameter object.

Removed the `shader_path` parameter and added the `root_path` parameter which references the library's path within the project. It is currently used by the instance and GUI renderers to load their associated shaders.