### PR TITLE
Deprecate Subcomponent.clone in favor of copy constructor

### DIFF
--- a/fonts/BitmapFont.js
+++ b/fonts/BitmapFont.js
@@ -185,7 +185,7 @@ export class BitmapFont extends Font {
 				continue;
 			}
 
-			glyph = this.#glyphs[string[i]].clone();
+			glyph = new Subcomponent(this.#glyphs[string[i]]);
 			glyph.setOffset(new Vector2(size[0] + this.getTileOffset(string[i]), 0));
 			glyph.setScale(new Vector2(fontSize, fontSize));
 			glyph.setColorMask(new Vector4(colorMask));
@@ -223,7 +223,7 @@ export class BitmapFont extends Font {
 					continue;
 				}
 
-				glyph = this.#glyphs[line[j]].clone();
+				glyph = new Subcomponent(this.#glyphs[line[j]]);
 				glyph.setOffset(new Vector2(lineWidth + this.getTileOffset(line[j]), size[1]));
 				glyph.setScale(new Vector2(fontSize, fontSize));
 				glyph.setColorMask(new Vector4(colorMask));

--- a/gui/Subcomponent.js
+++ b/gui/Subcomponent.js
@@ -39,14 +39,30 @@ export class Subcomponent {
 	#colorMask;
 
 	/**
+	 * @overload
 	 * @param {SubcomponentDescriptor} descriptor
+	 * 
+	 * @overload
+	 * @param {Subcomponent} subcomponent
 	 */
-	constructor(descriptor) {
-		this.#offset = descriptor.offset ?? new Vector2();
-		this.#size = descriptor.size;
-		this.#scale = descriptor.scale ?? new Vector2(1, 1);
-		this.#uv = descriptor.uv ?? new Vector2();
-		this.#colorMask = descriptor.colorMask ?? new Vector4(255, 255, 255, 255);
+	constructor() {
+		if (arguments[0] instanceof Subcomponent) {
+			const subcomponent = arguments[0];
+
+			this.#offset = subcomponent.getOffset();
+			this.#size = subcomponent.getSize();
+			this.#scale = subcomponent.getScale();
+			this.#uv = subcomponent.getUV();
+			this.#colorMask = subcomponent.getColorMask();
+		} else {
+			const descriptor = arguments[0];
+
+			this.#offset = descriptor.offset ?? new Vector2();
+			this.#size = descriptor.size;
+			this.#scale = descriptor.scale ?? new Vector2(1, 1);
+			this.#uv = descriptor.uv ?? new Vector2();
+			this.#colorMask = descriptor.colorMask ?? new Vector4(255, 255, 255, 255);
+		}
 	}
 
 	getOffset() {
@@ -104,6 +120,9 @@ export class Subcomponent {
 		this.#colorMask = colorMask;
 	}
 
+	/**
+	 * @deprecated
+	 */
 	clone() {
 		return new Subcomponent({
 			offset: this.#offset,


### PR DESCRIPTION
Added a copy constructor overload to the Subcomponent class, and deprecated its `clone` method, which will be replaced by the constructor in the next version.

The JSDoc will also properly show the constructor overloads.