### PR TITLE
Release v0.3.1

### DIFF
--- a/Composite.js
+++ b/Composite.js
@@ -9,7 +9,7 @@ import {Scene} from "./Scene/Scene.js";
  */
 
 /**
- * @todo Composites shoudn't have access to the instance
+ * @todo Composites should not have access to the instance
  * 
  * @abstract
  */

--- a/Instance.js
+++ b/Instance.js
@@ -136,7 +136,7 @@ export class Instance {
 	 */
 	getParameter(key) {
 		if (!(key in this._parameters)) {
-			return undefined;
+			return;
 		}
 
 		return this._parameters[key];
@@ -167,7 +167,7 @@ export class Instance {
 
 	async build() {
 		this.#renderer.setCompositeCount(this.#compositeCount);
-		this.#renderer.build(`${this._parameters["root_path"]}shaders/`);
+		await this.#renderer.build(`${this._parameters["root_path"]}shaders/`);
 
 		const viewport = new Vector4(0, 0, innerWidth, innerHeight)
 			.multiplyScalar(devicePixelRatio)
@@ -179,7 +179,6 @@ export class Instance {
 			composite = this.#composites[i];
 
 			await composite.build();
-
 			composite.getRenderer().setViewport(viewport);
 		}
 
@@ -302,7 +301,6 @@ export class Instance {
 			try {
 				this.#update(this.#frameIndex);
 				this.#renderer.render();
-				this.#frameIndex++;
 			} catch (error) {
 				console.error(error);
 
@@ -311,6 +309,8 @@ export class Instance {
 				this.#animationFrameRequestId = null;
 				this.#isRunning = false;
 			}
+
+			this.#frameIndex++;
 		}
 	}
 
@@ -332,7 +332,7 @@ export class Instance {
 	 */
 	#onKeyPressAndRepeat(event) {
 		if (this.#currentPressedKeys[event.code]) {
-			// Keyrepeat event
+			// Key repeat event
 			for (let i = 0; i < this.#compositeCount; i++) {
 				this.#composites[i].onKeyRepeat(event);
 			}

--- a/WebGLRenderer.js
+++ b/WebGLRenderer.js
@@ -112,7 +112,7 @@ export class WebGLRenderer {
 	 * @abstract
 	 * @param {String} shaderPath
 	 */
-	build(shaderPath) {}
+	async build(shaderPath) {}
 
 	/**
 	 * @param {String} vertexShaderSource

--- a/fonts/BitmapFont.js
+++ b/fonts/BitmapFont.js
@@ -185,7 +185,7 @@ export class BitmapFont extends Font {
 				continue;
 			}
 
-			glyph = this.#glyphs[string[i]].clone();
+			glyph = new Subcomponent(this.#glyphs[string[i]]);
 			glyph.setOffset(new Vector2(size[0] + this.getTileOffset(string[i]), 0));
 			glyph.setScale(new Vector2(fontSize, fontSize));
 			glyph.setColorMask(new Vector4(colorMask));
@@ -223,7 +223,7 @@ export class BitmapFont extends Font {
 					continue;
 				}
 
-				glyph = this.#glyphs[line[j]].clone();
+				glyph = new Subcomponent(this.#glyphs[line[j]]);
 				glyph.setOffset(new Vector2(lineWidth + this.getTileOffset(line[j]), size[1]));
 				glyph.setScale(new Vector2(fontSize, fontSize));
 				glyph.setColorMask(new Vector4(colorMask));

--- a/fonts/BitmapFont.js
+++ b/fonts/BitmapFont.js
@@ -188,7 +188,7 @@ export class BitmapFont extends Font {
 			glyph = this.#glyphs[string[i]].clone();
 			glyph.setOffset(new Vector2(size[0] + this.getTileOffset(string[i]), 0));
 			glyph.setScale(new Vector2(fontSize, fontSize));
-			glyph.setColorMask(colorMask.clone());
+			glyph.setColorMask(new Vector4(colorMask));
 
 			glyphs.push(glyph);
 
@@ -226,7 +226,7 @@ export class BitmapFont extends Font {
 				glyph = this.#glyphs[line[j]].clone();
 				glyph.setOffset(new Vector2(lineWidth + this.getTileOffset(line[j]), size[1]));
 				glyph.setScale(new Vector2(fontSize, fontSize));
-				glyph.setColorMask(colorMask.clone());
+				glyph.setColorMask(new Vector4(colorMask));
 
 				glyphs.push(glyph);
 

--- a/gui/Component/Component.js
+++ b/gui/Component/Component.js
@@ -120,8 +120,7 @@ export class Component {
 		const marginDisplacement = new Vector2(x & 1, y & 1)
 			.multiplyScalar(-2)
 			.addScalar(1);
-		const margin = this.#margin
-			.clone()
+		const margin = new Vector2(this.#margin)
 			.multiply(marginDisplacement);
 
 		this.#position = initial

--- a/gui/Component/StructuralComponent/Group.js
+++ b/gui/Component/StructuralComponent/Group.js
@@ -3,8 +3,8 @@ import {Vector2} from "../../../math/index.js";
 
 export class Group extends StructuralComponent {
 	/**
-	 * @param {Vector2} initial Cloned parent top left corner
-	 * @param {Vector2} parentSize Cloned parent size
+	 * @param {Vector2} initial Copy of the parent top left corner
+	 * @param {Vector2} parentSize Copy of the parent size
 	 */
 	compute(initial, parentSize) {
 		super.compute(initial, parentSize);
@@ -12,7 +12,7 @@ export class Group extends StructuralComponent {
 		const children = this.getChildren();
 
 		for (let i = 0; i < children.length; i++) {
-			children[i].compute(this.getPosition().clone(), this.getSize().clone());
+			children[i].compute(new Vector2(this.getPosition()), new Vector2(this.getSize()));
 		}
 	}
 }

--- a/gui/GUIComposite.js
+++ b/gui/GUIComposite.js
@@ -235,13 +235,11 @@ export class GUIComposite extends Composite {
 	 * The new components will be rendered on top of the previous ones.
 	 * 
 	 * @param {Layer} layer
-	 * @throws {Error} if the layer didn't return a component
 	 */
 	push(layer) {
 		this.#layerStack.push(layer);
 
 		this._scene.resetSubcomponentCount();
-		// this.#animatedComponents.length = 0;
 
 		// Mark the tree length as the extraction index for this layer
 		this.#lastInsertionIndices.push(this.#tree.length);

--- a/gui/GUIComposite.js
+++ b/gui/GUIComposite.js
@@ -147,7 +147,7 @@ export class GUIComposite extends Composite {
 			.divideScalar(this.getInstance().getParameter("current_scale"));
 
 		for (let i = 0, l = this.#rootComponents.length; i < l; i++) {
-			this.#rootComponents[i].compute(new Vector2(), parentSize.clone());
+			this.#rootComponents[i].compute(new Vector2(), new Vector2(parentSize));
 		}
 	}
 

--- a/gui/GUIRenderer.js
+++ b/gui/GUIRenderer.js
@@ -37,7 +37,7 @@ export class GUIRenderer extends WebGLRenderer {
 	 * @param {String} shaderPath
 	 */
 	async build(shaderPath) {
-		super.build(shaderPath);
+		await super.build(shaderPath);
 
 		this._canvas = new OffscreenCanvas(0, 0);
 		this._context = this._canvas.getContext("webgl2");

--- a/gui/GUIRenderer.js
+++ b/gui/GUIRenderer.js
@@ -1,6 +1,6 @@
 import {WebGLRenderer} from "../index.js";
 import {ShaderLoader} from "../Loader/index.js";
-import {Matrix3, Vector4} from "../math/index.js";
+import {Matrix3, Vector2, Vector4} from "../math/index.js";
 import {GUIScene} from "../Scene/index.js";
 
 export class GUIRenderer extends WebGLRenderer {
@@ -134,11 +134,11 @@ export class GUIRenderer extends WebGLRenderer {
 				subcomponent = subcomponents[j];
 				size = subcomponent.getSize();
 				world = Matrix3
-					.translation(position.clone().add(subcomponent.getOffset()))
-					.multiply(Matrix3.scale(size.clone().multiply(subcomponent.getScale())));
+					.translation(new Vector2(position).add(subcomponent.getOffset()))
+					.multiply(Matrix3.scale(new Vector2(size).multiply(subcomponent.getScale())));
 				texture = Matrix3
-					.translation(subcomponent.getUV().clone().divide(WebGLRenderer.MAX_TEXTURE_SIZE))
-					.multiply(Matrix3.scale(size.clone().divide(WebGLRenderer.MAX_TEXTURE_SIZE)));
+					.translation(new Vector2(subcomponent.getUV()).divide(WebGLRenderer.MAX_TEXTURE_SIZE))
+					.multiply(Matrix3.scale(new Vector2(size).divide(WebGLRenderer.MAX_TEXTURE_SIZE)));
 
 				worlds.set(world, k * 9);
 				textureIndices.set(textureIndex, k);

--- a/gui/Subcomponent.js
+++ b/gui/Subcomponent.js
@@ -39,14 +39,30 @@ export class Subcomponent {
 	#colorMask;
 
 	/**
+	 * @overload
 	 * @param {SubcomponentDescriptor} descriptor
+	 * 
+	 * @overload
+	 * @param {Subcomponent} subcomponent
 	 */
-	constructor(descriptor) {
-		this.#offset = descriptor.offset ?? new Vector2();
-		this.#size = descriptor.size;
-		this.#scale = descriptor.scale ?? new Vector2(1, 1);
-		this.#uv = descriptor.uv ?? new Vector2();
-		this.#colorMask = descriptor.colorMask ?? new Vector4(255, 255, 255, 255);
+	constructor() {
+		if (arguments[0] instanceof Subcomponent) {
+			const subcomponent = arguments[0];
+
+			this.#offset = subcomponent.getOffset();
+			this.#size = subcomponent.getSize();
+			this.#scale = subcomponent.getScale();
+			this.#uv = subcomponent.getUV();
+			this.#colorMask = subcomponent.getColorMask();
+		} else {
+			const descriptor = arguments[0];
+
+			this.#offset = descriptor.offset ?? new Vector2();
+			this.#size = descriptor.size;
+			this.#scale = descriptor.scale ?? new Vector2(1, 1);
+			this.#uv = descriptor.uv ?? new Vector2();
+			this.#colorMask = descriptor.colorMask ?? new Vector4(255, 255, 255, 255);
+		}
 	}
 
 	getOffset() {
@@ -104,6 +120,9 @@ export class Subcomponent {
 		this.#colorMask = colorMask;
 	}
 
+	/**
+	 * @deprecated
+	 */
 	clone() {
 		return new Subcomponent({
 			offset: this.#offset,


### PR DESCRIPTION
### Deprecations

> **Note:** Deprecated members will **always** be deleted on the next major or minor version.

- Added a copy constructor overload to [Matrix](https://github.com/matteokeole/math/blob/main/Matrix.js), [Vector](https://github.com/matteokeole/math/blob/main/Vector.js) and [Subcomponent](https://github.com/matteokeole/raven/blob/main/gui/Subcomponent.js) classes, and deprecated their `clone` methods, which are replaced by copy constructors (the library has already been updated to the constructors).  
  The JSDoc will also properly show the constructor overloads.
- Deprecated the [Vector](https://github.com/matteokeole/math/blob/main/Vector.js) `to` method since it has no real benefit to be in the API.

### Refactoring

- Small style refactors.
- JSDoc annotation fixes.