### PR TITLE
Remove deprecated methods

### DIFF
--- a/gui/Component/Component.js
+++ b/gui/Component/Component.js
@@ -107,8 +107,8 @@ export class Component {
 	/**
 	 * Calculates the component absolute position.
 	 * 
-	 * @param {Vector2} initial Cloned parent top left corner
-	 * @param {Vector2} parentSize Cloned parent size
+	 * @param {Vector2} initial Copy of the parent top left corner
+	 * @param {Vector2} parentSize Copy of the parent size
 	 */
 	compute(initial, parentSize) {
 		const x = ((this.#alignment & 0b111000) >> 4) * .5;

--- a/gui/Subcomponent.js
+++ b/gui/Subcomponent.js
@@ -119,17 +119,4 @@ export class Subcomponent {
 	setColorMask(colorMask) {
 		this.#colorMask = colorMask;
 	}
-
-	/**
-	 * @deprecated
-	 */
-	clone() {
-		return new Subcomponent({
-			offset: this.#offset,
-			size: this.#size,
-			scale: this.#scale,
-			uv: this.#uv,
-			colorMask: this.#colorMask,
-		});
-	}
 }


### PR DESCRIPTION
Removed the following deprecated methods:
- Matrix.clone
- Matrix3.clone
- Matrix4.clone
- Vector.clone
- Vector.to
- Vector2.clone
- Vector3.clone
- Vector4.clone
- Subcomponent.clone