### PR TITLE
WebGL shader API

### DIFF
--- a/Error/ProgramLinkingError.js
+++ b/Error/ProgramLinkingError.js
@@ -1,0 +1,8 @@
+export class ProgramLinkingError extends Error {
+	/**
+	 * @param {String} log Program info log
+	 */
+	constructor(log) {
+		super(`PROGRAM LINKING ERROR: ${log}`);
+	}
+}

--- a/Error/ShaderCompilationError.js
+++ b/Error/ShaderCompilationError.js
@@ -1,9 +1,17 @@
 export class ShaderCompilationError extends Error {
 	/**
-	 * @param {String} message Shader info log
-	 * @param {String} type Shader type
+	 * @type {Record.<GLenum, String>}
 	 */
-	constructor(message, type) {
-		super(`${type} ${message}`);
+	static #TYPES = {
+		[WebGL2RenderingContext.VERTEX_SHADER]: "VERTEX",
+		[WebGL2RenderingContext.FRAGMENT_SHADER]: "FRAGMENT",
+	};
+
+	/**
+	 * @param {GLenum} type Shader type
+	 * @param {String} log Shader info log
+	 */
+	constructor(type, log) {
+		super(`${ShaderCompilationError.#TYPES[type]} SHADER COMPILATION ${log}`);
 	}
 }

--- a/Error/index.js
+++ b/Error/index.js
@@ -1,3 +1,4 @@
 export {NotImplementedError} from "./NotImplementedError.js";
 export {NoWebGL2Error} from "./NoWebGL2Error.js";
+export {ProgramLinkingError} from "./ProgramLinkingError.js";
 export {ShaderCompilationError} from "./ShaderCompilationError.js";


### PR DESCRIPTION
- Create the ProgramLinkingError class for [WebGL program](https://developer.mozilla.org/en-US/docs/Web/API/WebGLProgram) linking failure
- Update the ShaderCompilationError class to accept a GLenum `type` instead of a string.
- Update the WebGLRenderer._createProgram method. The method now checks both vertex and fragment shader compilation statuses along with the program link status, and deletes unnecessary shaders and/or program if an error happens. The shaders are also detached right before returning the linked program.
- Delete the WebGLRenderer.#createShader method, as it did not check the compilation status.