### PR TITLE
Buffer API (Buffer, IndexBuffer, VertexBuffer)

### DIFF
--- a/Buffer/Buffer.js
+++ b/Buffer/Buffer.js
@@ -1,0 +1,24 @@
+/**
+ * @abstract
+ */
+export class Buffer {
+	/**
+	 * @type {Object}
+	 */
+	_context;
+
+	/**
+	 * @type {Object}
+	 */
+	_buffer;
+
+	/**
+	 * @abstract
+	 */
+	bind() {}
+
+	/**
+	 * @abstract
+	 */
+	unbind() {}
+}

--- a/Buffer/IndexBuffer.js
+++ b/Buffer/IndexBuffer.js
@@ -1,0 +1,15 @@
+import {Buffer} from "./Buffer.js";
+
+/**
+ * @abstract
+ */
+export class IndexBuffer extends Buffer {
+	/**
+	 * @type {Object}
+	 */
+	_type;
+
+	getType() {
+		return this._type;
+	}
+}

--- a/Buffer/IndexBuffer.js
+++ b/Buffer/IndexBuffer.js
@@ -7,9 +7,9 @@ export class IndexBuffer extends Buffer {
 	/**
 	 * @type {Object}
 	 */
-	_type;
+	_format;
 
-	getType() {
-		return this._type;
+	getFormat() {
+		return this._format;
 	}
 }

--- a/Buffer/VertexBuffer.js
+++ b/Buffer/VertexBuffer.js
@@ -1,0 +1,6 @@
+import {Buffer} from "./Buffer.js";
+
+/**
+ * @abstract
+ */
+export class VertexBuffer extends Buffer {}

--- a/Buffer/WebGL/WebGLIndexBuffer.js
+++ b/Buffer/WebGL/WebGLIndexBuffer.js
@@ -1,0 +1,39 @@
+import {IndexBuffer} from "../IndexBuffer.js";
+
+export class WebGLIndexBuffer extends IndexBuffer {
+	/**
+	 * @override
+	 * @type {WebGL2RenderingContext}
+	 */
+	_context = null;
+
+	/**
+	 * @type {GLenum}
+	 */
+	_type = null;
+
+	/**
+	 * @param {WebGL2RenderingContext} context
+	 * @param {ArrayBuffer} indices
+	 * @param {GLenum} type
+	 */
+	constructor(context, indices, type) {
+		super();
+
+		this._context = context;
+		this._type = type;
+		this._buffer = this._context.createBuffer();
+
+		this.bind();
+
+		this._context.bufferData(this._context.ELEMENT_ARRAY_BUFFER, indices, this._context.STATIC_DRAW);
+	}
+
+	bind() {
+		this._context.bindBuffer(this._context.ELEMENT_ARRAY_BUFFER, this._buffer);
+	}
+
+	unbind() {
+		this._context.bindBuffer(this._context.ELEMENT_ARRAY_BUFFER, null);
+	}
+}

--- a/Buffer/WebGL/WebGLIndexBuffer.js
+++ b/Buffer/WebGL/WebGLIndexBuffer.js
@@ -8,20 +8,21 @@ export class WebGLIndexBuffer extends IndexBuffer {
 	_context = null;
 
 	/**
+	 * @override
 	 * @type {GLenum}
 	 */
-	_type = null;
+	_format = null;
 
 	/**
 	 * @param {WebGL2RenderingContext} context
 	 * @param {ArrayBuffer} indices
-	 * @param {GLenum} type
+	 * @param {GLenum} format
 	 */
-	constructor(context, indices, type) {
+	constructor(context, indices, format) {
 		super();
 
 		this._context = context;
-		this._type = type;
+		this._format = format;
 		this._buffer = this._context.createBuffer();
 
 		this.bind();

--- a/Buffer/WebGL/WebGLVertexBuffer.js
+++ b/Buffer/WebGL/WebGLVertexBuffer.js
@@ -1,0 +1,32 @@
+import {VertexBuffer} from "../VertexBuffer.js";
+
+export class WebGLVertexBuffer extends VertexBuffer {
+	/**
+	 * @override
+	 * @type {WebGL2RenderingContext}
+	 */
+	_context = null;
+
+	/**
+	 * @param {WebGL2RenderingContext} context
+	 * @param {ArrayBuffer} vertices
+	 */
+	constructor(context, vertices) {
+		super();
+
+		this._context = context;
+		this._buffer = this._context.createBuffer();
+
+		this.bind();
+
+		this._context.bufferData(this._context.ARRAY_BUFFER, vertices, this._context.STATIC_DRAW);
+	}
+
+	bind() {
+		this._context.bindBuffer(this._context.ARRAY_BUFFER, this._buffer);
+	}
+
+	unbind() {
+		this._context.bindBuffer(this._context.ARRAY_BUFFER, null);
+	}
+}

--- a/Buffer/WebGL/index.js
+++ b/Buffer/WebGL/index.js
@@ -1,0 +1,2 @@
+export {WebGLIndexBuffer} from "./WebGLIndexBuffer.js";
+export {WebGLVertexBuffer} from "./WebGLVertexBuffer.js";

--- a/Buffer/index.js
+++ b/Buffer/index.js
@@ -1,0 +1,3 @@
+export {Buffer} from "./Buffer.js";
+export {IndexBuffer} from "./IndexBuffer.js";
+export {VertexBuffer} from "./VertexBuffer.js";

--- a/Renderer/Renderer.js
+++ b/Renderer/Renderer.js
@@ -1,3 +1,6 @@
+import {IndexBuffer, VertexBuffer} from "../Buffer/index.js";
+import {NotImplementedError} from "../Error/index.js";
+
 /**
  * @abstract
  */
@@ -9,5 +12,23 @@ export class Renderer {
 
 	getCanvas() {
 		return this._canvas;
+	}
+
+	/**
+	 * @abstract
+	 * @param {ArrayBuffer} indices
+	 * @returns {IndexBuffer}
+	 */
+	_createIndexBuffer(indices) {
+		throw new NotImplementedError();
+	}
+
+	/**
+	 * @abstract
+	 * @param {ArrayBuffer} vertices
+	 * @returns {VertexBuffer}
+	 */
+	_createVertexBuffer(vertices) {
+		throw new NotImplementedError();
 	}
 }

--- a/Renderer/WebGLRenderer.js
+++ b/Renderer/WebGLRenderer.js
@@ -125,7 +125,7 @@ export class WebGLRenderer extends Renderer {
 		this._context.compileShader(vertexShader);
 
 		/**
-		 * @type {Boolean}
+		 * @type {GLboolean}
 		 */
 		let compileStatus = this._context.getShaderParameter(vertexShader, this._context.COMPILE_STATUS);
 
@@ -160,7 +160,7 @@ export class WebGLRenderer extends Renderer {
 		this._context.linkProgram(program);
 
 		/**
-		 * @type {Boolean}
+		 * @type {GLboolean}
 		 */
 		const linkStatus = this._context.getProgramParameter(program, this._context.LINK_STATUS);
 

--- a/Renderer/WebGLRenderer.js
+++ b/Renderer/WebGLRenderer.js
@@ -1,4 +1,6 @@
 import {Renderer} from "./Renderer.js";
+import {IndexBuffer, VertexBuffer} from "../Buffer/index.js";
+import {WebGLIndexBuffer, WebGLVertexBuffer} from "../Buffer/WebGL/index.js";
 import {ProgramLinkingError, ShaderCompilationError} from "../Error/index.js";
 import {Matrix, Vector2, Vector4} from "../math/index.js";
 import {Scene} from "../Scene/Scene.js";
@@ -178,6 +180,24 @@ export class WebGLRenderer extends Renderer {
 		this._context.detachShader(program, fragmentShader);
 
 		return program;
+	}
+
+	/**
+	 * Note: Index buffers can only store unsigned bytes.
+	 * 
+	 * @param {ArrayBuffer} indices
+	 * @returns {IndexBuffer}
+	 */
+	_createIndexBuffer(indices) {
+		return new WebGLIndexBuffer(this._context, indices, this._context.UNSIGNED_BYTE);
+	}
+
+	/**
+	 * @param {ArrayBuffer} vertices
+	 * @returns {VertexBuffer}
+	 */
+	_createVertexBuffer(vertices) {
+		return new WebGLVertexBuffer(this._context, vertices);
 	}
 
 	/**


### PR DESCRIPTION
### Abstraction

- Create Buffer to represent a generic buffer.
- Create IndexBuffer to represent a generic index buffer.
- Create VertexBuffer to represent a generic vertex buffer.
- Create Renderer._createIndexBuffer to create an IndexBuffer, depending on the underlying API.
- Create Renderer._createVertexBuffer to create a VertexBuffer, depending on the underlying API.

### WebGL implementation

- Create WebGLIndexBuffer to represent a WebGL index buffer (that uses the `ELEMENT_ARRAY_BUFFER` bind point).
- Create WebGLVertexBuffer to represent a WebGL vertex buffer (that uses the `ARRAY_BUFFER` bind point).
- Create WebGLRenderer._createIndexBuffer to create a WebGLIndexBuffer. *Note that index buffers can only store unsigned bytes at the moment.*
- Create WebGLRenderer._createVertexBuffer to create a WebGLVertexBuffer.