### PR TITLE
Expand Buffer API abstraction

### DIFF
--- a/Buffer/Buffer.js
+++ b/Buffer/Buffer.js
@@ -5,11 +5,6 @@ export class Buffer {
 	/**
 	 * @type {Object}
 	 */
-	_context;
-
-	/**
-	 * @type {Object}
-	 */
 	_buffer;
 
 	/**

--- a/Buffer/WebGL/WebGLIndexBuffer.js
+++ b/Buffer/WebGL/WebGLIndexBuffer.js
@@ -1,11 +1,10 @@
-import {IndexBuffer} from "../IndexBuffer.js";
+import {IndexBuffer} from "../index.js";
 
 export class WebGLIndexBuffer extends IndexBuffer {
 	/**
-	 * @override
 	 * @type {WebGL2RenderingContext}
 	 */
-	_context = null;
+	_context;
 
 	/**
 	 * @override

--- a/Buffer/WebGL/WebGLVertexBuffer.js
+++ b/Buffer/WebGL/WebGLVertexBuffer.js
@@ -1,11 +1,10 @@
-import {VertexBuffer} from "../VertexBuffer.js";
+import {VertexBuffer} from "../index.js";
 
 export class WebGLVertexBuffer extends VertexBuffer {
 	/**
-	 * @override
 	 * @type {WebGL2RenderingContext}
 	 */
-	_context = null;
+	_context;
 
 	/**
 	 * @param {WebGL2RenderingContext} context

--- a/Buffer/WebGPU/IndexBuffer.js
+++ b/Buffer/WebGPU/IndexBuffer.js
@@ -1,0 +1,41 @@
+import {IndexBuffer} from "../index.js";
+
+export class WebGPUIndexBuffer extends IndexBuffer {
+	/**
+	 * @type {GPUDevice}
+	 */
+	_device;
+
+	/**
+	 * @todo The format can only be set when using a {@link GPURenderPassEncoder}
+	 * 
+	 * @param {GPUDevice} device
+	 * @param {ArrayBuffer} indices
+	 * @param {GLenum} format
+	 */
+	constructor(device, indices, format) {
+		super();
+
+		this._device = device;
+		this._format = format;
+		this._buffer = this._device.createBuffer({
+			label: WebGPUIndexBuffer.name,
+			size: indices.byteLength,
+			usage: GPUBufferUsage.INDEX,
+		});
+
+		this.bind();
+
+		this._device.queue.writeBuffer(this._buffer, 0, indices);
+	}
+
+	/**
+	 * @todo The index buffer can only be bound to a {@link GPURenderPassEncoder}
+	 */
+	bind() {}
+
+	/**
+	 * @todo The index buffer can only be bound to a {@link GPURenderPassEncoder}
+	 */
+	unbind() {}
+}

--- a/Buffer/WebGPU/VertexBuffer.js
+++ b/Buffer/WebGPU/VertexBuffer.js
@@ -1,0 +1,39 @@
+import {VertexBuffer} from "../index.js";
+
+export class WebGPUVertexBuffer extends VertexBuffer {
+	/**
+	 * @type {GPUDevice}
+	 */
+	_device;
+
+	/**
+	 * @todo The format can only be set when using a {@link GPURenderPassEncoder}
+	 * 
+	 * @param {GPUDevice} device
+	 * @param {ArrayBuffer} vertices
+	 */
+	constructor(device, vertices) {
+		super();
+
+		this._device = device;
+		this._buffer = this._device.createBuffer({
+			label: WebGPUVertexBuffer.name,
+			size: vertices.byteLength,
+			usage: GPUBufferUsage.VERTEX,
+		});
+
+		this.bind();
+
+		this._device.queue.writeBuffer(this._buffer, 0, vertices);
+	}
+
+	/**
+	 * @todo The vertex buffer can only be bound to a {@link GPURenderPassEncoder}
+	 */
+	bind() {}
+
+	/**
+	 * @todo The vertex buffer can only be bound to a {@link GPURenderPassEncoder}
+	 */
+	unbind() {}
+}

--- a/Buffer/WebGPU/index.js
+++ b/Buffer/WebGPU/index.js
@@ -1,0 +1,2 @@
+export {WebGPUIndexBuffer} from "./IndexBuffer.js";
+export {WebGPUVertexBuffer} from "./VertexBuffer.js";


### PR DESCRIPTION
### Fixes

- Move Buffer._context property to the WebGL sub-classes to allow abstracting APIs that don't need it

### Experimental features

- Add WebGPUVertexBuffer class
- Add WebGPUIndexBuffer class